### PR TITLE
Panic when we can't convert between Prana and TiDB types.

### DIFF
--- a/common/conversion.go
+++ b/common/conversion.go
@@ -7,46 +7,46 @@ import (
 	"github.com/pingcap/parser/types"
 )
 
-func ConvertPranaTypeToTiDBType(columnType ColumnType) (*types.FieldType, error) {
+func ConvertPranaTypeToTiDBType(columnType ColumnType) *types.FieldType {
 	switch columnType.Type {
 	case TypeTinyInt:
-		return types.NewFieldType(mysql.TypeTiny), nil
+		return types.NewFieldType(mysql.TypeTiny)
 	case TypeInt:
-		return types.NewFieldType(mysql.TypeLong), nil
+		return types.NewFieldType(mysql.TypeLong)
 	case TypeBigInt:
-		return types.NewFieldType(mysql.TypeLonglong), nil
+		return types.NewFieldType(mysql.TypeLonglong)
 	case TypeDouble:
-		return types.NewFieldType(mysql.TypeDouble), nil
+		return types.NewFieldType(mysql.TypeDouble)
 	case TypeDecimal:
-		return types.NewFieldType(mysql.TypeNewDecimal), nil
+		return types.NewFieldType(mysql.TypeNewDecimal)
 	case TypeVarchar:
-		return types.NewFieldType(mysql.TypeVarchar), nil
+		return types.NewFieldType(mysql.TypeVarchar)
 	case TypeTimestamp:
-		return types.NewFieldType(mysql.TypeTimestamp), nil
+		return types.NewFieldType(mysql.TypeTimestamp)
 	default:
-		return nil, fmt.Errorf("unknown colum type %d", columnType)
+		panic(fmt.Sprintf("unknown column type %d", columnType))
 	}
 }
 
-func ConvertTiDBTypeToPranaType(columnType *types.FieldType) (ColumnType, error) {
+func ConvertTiDBTypeToPranaType(columnType *types.FieldType) ColumnType {
 	switch columnType.Tp {
 	case mysql.TypeTiny:
-		return TinyIntColumnType, nil
+		return TinyIntColumnType
 	case mysql.TypeLong:
-		return IntColumnType, nil
+		return IntColumnType
 	case mysql.TypeLonglong:
-		return BigIntColumnType, nil
+		return BigIntColumnType
 	case mysql.TypeDouble:
-		return DoubleColumnType, nil
+		return DoubleColumnType
 	case mysql.TypeNewDecimal:
 		precision := columnType.Flen
 		scale := columnType.Decimal
-		return NewDecimalColumnType(precision, scale), nil
+		return NewDecimalColumnType(precision, scale)
 	case mysql.TypeVarchar:
-		return VarcharColumnType, nil
+		return VarcharColumnType
 	case mysql.TypeTimestamp:
-		return TimestampColumnType, nil
+		return TimestampColumnType
 	default:
-		return ColumnType{}, fmt.Errorf("unknown colum type %d", columnType.Tp)
+		panic(fmt.Sprintf("unknown colum type %d", columnType.Tp))
 	}
 }

--- a/common/encoding_test.go
+++ b/common/encoding_test.go
@@ -12,8 +12,7 @@ var singleIntColumn = []ColumnType{IntColumnType}
 var singleFloatColumn = []ColumnType{DoubleColumnType}
 
 func TestEncodeDecodeInt(t *testing.T) {
-	rf, err := NewRowsFactory(singleIntColumn)
-	require.Nil(t, err)
+	rf := NewRowsFactory(singleIntColumn)
 	encodeDecodeInt(t, rf, 0)
 	encodeDecodeInt(t, rf, math.MinInt64)
 	encodeDecodeInt(t, rf, math.MaxInt64)
@@ -24,16 +23,14 @@ func TestEncodeDecodeInt(t *testing.T) {
 }
 
 func TestEncodeDecodeString(t *testing.T) {
-	rf, err := NewRowsFactory(singleVarcharColumn)
-	require.Nil(t, err)
+	rf := NewRowsFactory(singleVarcharColumn)
 	encodeDecodeString(t, rf, "")
 	encodeDecodeString(t, rf, "zxy123")
 	encodeDecodeString(t, rf, "\u2318")
 }
 
 func TestEncodeDecodeFloat(t *testing.T) {
-	rf, err := NewRowsFactory(singleFloatColumn)
-	require.Nil(t, err)
+	rf := NewRowsFactory(singleFloatColumn)
 	encodeDecodeFloat(t, rf, 0)
 	encodeDecodeFloat(t, rf, -1234.5678)
 	encodeDecodeFloat(t, rf, 1234.5678)
@@ -43,8 +40,7 @@ func TestEncodeDecodeFloat(t *testing.T) {
 func TestEncodeDecodeRow(t *testing.T) {
 	decType1 := NewDecimalColumnType(10, 2)
 	colTypes := []ColumnType{TinyIntColumnType, IntColumnType, BigIntColumnType, DoubleColumnType, VarcharColumnType, decType1}
-	rf, err := NewRowsFactory(colTypes)
-	require.Nil(t, err)
+	rf := NewRowsFactory(colTypes)
 	rows := rf.NewRows(10)
 	rows.AppendInt64ToColumn(0, 255)
 	rows.AppendInt64ToColumn(1, math.MaxInt32)
@@ -60,8 +56,7 @@ func TestEncodeDecodeRow(t *testing.T) {
 func TestEncodeDecodeRowWithNulls(t *testing.T) {
 	decType1 := NewDecimalColumnType(10, 2)
 	colTypes := []ColumnType{TinyIntColumnType, TinyIntColumnType, IntColumnType, IntColumnType, BigIntColumnType, BigIntColumnType, DoubleColumnType, DoubleColumnType, VarcharColumnType, VarcharColumnType, decType1, decType1}
-	rf, err := NewRowsFactory(colTypes)
-	require.Nil(t, err)
+	rf := NewRowsFactory(colTypes)
 	rows := rf.NewRows(10)
 	rows.AppendInt64ToColumn(0, 255)
 	rows.AppendNullToColumn(1)
@@ -94,8 +89,7 @@ func testEncodeDecodeRow(t *testing.T, rows *Rows, colTypes []ColumnType) {
 
 func TestEncodeDecodeDecimal(t *testing.T) {
 	colTypes := []ColumnType{NewDecimalColumnType(10, 2)}
-	rf, err := NewRowsFactory(colTypes)
-	require.Nil(t, err)
+	rf := NewRowsFactory(colTypes)
 	dec, err := NewDecFromString("0.00")
 	require.Nil(t, err)
 	encodeDecodeDecimal(t, rf, *dec, colTypes)

--- a/common/expression.go
+++ b/common/expression.go
@@ -3,6 +3,7 @@ package common
 import (
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/types"
+
 	"github.com/squareup/pranadb/sessctx"
 )
 
@@ -10,48 +11,36 @@ type Expression struct {
 	expression expression.Expression
 }
 
-func NewColumnExpression(colIndex int, colType ColumnType) (*Expression, error) {
-	tiDBType, err := ConvertPranaTypeToTiDBType(colType)
-	if err != nil {
-		return nil, err
-	}
+func NewColumnExpression(colIndex int, colType ColumnType) *Expression {
+	tiDBType := ConvertPranaTypeToTiDBType(colType)
 	col := &expression.Column{RetType: tiDBType, Index: colIndex}
-	return &Expression{expression: col}, nil
+	return &Expression{expression: col}
 }
 
-func NewConstantInt(colType ColumnType, val int64) (*Expression, error) {
-	tiDBType, err := ConvertPranaTypeToTiDBType(colType)
-	if err != nil {
-		return nil, err
-	}
+func NewConstantInt(colType ColumnType, val int64) *Expression {
+	tiDBType := ConvertPranaTypeToTiDBType(colType)
 	datum := types.Datum{}
 	datum.SetInt64(val)
 	con := &expression.Constant{
 		Value:   datum,
 		RetType: tiDBType,
 	}
-	return &Expression{expression: con}, nil
+	return &Expression{expression: con}
 }
 
-func NewConstantDouble(colType ColumnType, val float64) (*Expression, error) {
-	tiDBType, err := ConvertPranaTypeToTiDBType(colType)
-	if err != nil {
-		return nil, err
-	}
+func NewConstantDouble(colType ColumnType, val float64) *Expression {
+	tiDBType := ConvertPranaTypeToTiDBType(colType)
 	datum := types.Datum{}
 	datum.SetFloat64(val)
 	con := &expression.Constant{
 		Value:   datum,
 		RetType: tiDBType,
 	}
-	return &Expression{expression: con}, nil
+	return &Expression{expression: con}
 }
 
-func NewConstantVarchar(colType ColumnType, val string) (*Expression, error) {
-	tiDBType, err := ConvertPranaTypeToTiDBType(colType)
-	if err != nil {
-		return nil, err
-	}
+func NewConstantVarchar(colType ColumnType, val string) *Expression {
+	tiDBType := ConvertPranaTypeToTiDBType(colType)
 	datum := types.Datum{}
 	// This is the default collation for UTF-8, not sure it matters for our usage
 	datum.SetString(val, "utf8mb4_0900_ai_ci")
@@ -59,14 +48,11 @@ func NewConstantVarchar(colType ColumnType, val string) (*Expression, error) {
 		Value:   datum,
 		RetType: tiDBType,
 	}
-	return &Expression{expression: con}, nil
+	return &Expression{expression: con}
 }
 
 func NewScalarFunctionExpression(colType ColumnType, funcName string, args ...*Expression) (*Expression, error) {
-	tiDBType, err := ConvertPranaTypeToTiDBType(colType)
-	if err != nil {
-		return nil, err
-	}
+	tiDBType := ConvertPranaTypeToTiDBType(colType)
 	tiDBArgs := make([]expression.Expression, len(args))
 	for i, ex := range args {
 		tiDBArgs[i] = ex.expression

--- a/common/expression_test.go
+++ b/common/expression_test.go
@@ -8,8 +8,7 @@ import (
 
 func TestColumnExpressionTinyInt(t *testing.T) {
 	row := createRow(t)
-	colExpr, err := NewColumnExpression(0, TinyIntColumnType)
-	require.Nil(t, err)
+	colExpr := NewColumnExpression(0, TinyIntColumnType)
 	val, null, err := colExpr.EvalInt64(row)
 	require.Nil(t, err)
 	require.False(t, null)
@@ -18,8 +17,7 @@ func TestColumnExpressionTinyInt(t *testing.T) {
 
 func TestColumnExpressionNullTinyInt(t *testing.T) {
 	row := createRow(t)
-	colExpr, err := NewColumnExpression(1, TinyIntColumnType)
-	require.Nil(t, err)
+	colExpr := NewColumnExpression(1, TinyIntColumnType)
 	_, null, err := colExpr.EvalInt64(row)
 	require.Nil(t, err)
 	require.True(t, null)
@@ -27,8 +25,7 @@ func TestColumnExpressionNullTinyInt(t *testing.T) {
 
 func TestColumnExpressionInt(t *testing.T) {
 	row := createRow(t)
-	colExpr, err := NewColumnExpression(2, IntColumnType)
-	require.Nil(t, err)
+	colExpr := NewColumnExpression(2, IntColumnType)
 	val, null, err := colExpr.EvalInt64(row)
 	require.Nil(t, err)
 	require.False(t, null)
@@ -37,8 +34,7 @@ func TestColumnExpressionInt(t *testing.T) {
 
 func TestColumnExpressionNullInt(t *testing.T) {
 	row := createRow(t)
-	colExpr, err := NewColumnExpression(3, IntColumnType)
-	require.Nil(t, err)
+	colExpr := NewColumnExpression(3, IntColumnType)
 	_, null, err := colExpr.EvalInt64(row)
 	require.Nil(t, err)
 	require.True(t, null)
@@ -46,8 +42,7 @@ func TestColumnExpressionNullInt(t *testing.T) {
 
 func TestColumnExpressionBigInt(t *testing.T) {
 	row := createRow(t)
-	colExpr, err := NewColumnExpression(4, BigIntColumnType)
-	require.Nil(t, err)
+	colExpr := NewColumnExpression(4, BigIntColumnType)
 	val, null, err := colExpr.EvalInt64(row)
 	require.Nil(t, err)
 	require.False(t, null)
@@ -56,8 +51,7 @@ func TestColumnExpressionBigInt(t *testing.T) {
 
 func TestColumnExpressionNullBigInt(t *testing.T) {
 	row := createRow(t)
-	colExpr, err := NewColumnExpression(5, BigIntColumnType)
-	require.Nil(t, err)
+	colExpr := NewColumnExpression(5, BigIntColumnType)
 	_, null, err := colExpr.EvalInt64(row)
 	require.Nil(t, err)
 	require.True(t, null)
@@ -65,8 +59,7 @@ func TestColumnExpressionNullBigInt(t *testing.T) {
 
 func TestColumnExpressionDouble(t *testing.T) {
 	row := createRow(t)
-	colExpr, err := NewColumnExpression(6, DoubleColumnType)
-	require.Nil(t, err)
+	colExpr := NewColumnExpression(6, DoubleColumnType)
 	val, null, err := colExpr.EvalFloat64(row)
 	require.Nil(t, err)
 	require.False(t, null)
@@ -75,8 +68,7 @@ func TestColumnExpressionDouble(t *testing.T) {
 
 func TestColumnExpressionNullDouble(t *testing.T) {
 	row := createRow(t)
-	colExpr, err := NewColumnExpression(7, DoubleColumnType)
-	require.Nil(t, err)
+	colExpr := NewColumnExpression(7, DoubleColumnType)
 	_, null, err := colExpr.EvalFloat64(row)
 	require.Nil(t, err)
 	require.True(t, null)
@@ -84,8 +76,7 @@ func TestColumnExpressionNullDouble(t *testing.T) {
 
 func TestColumnExpressionVarchar(t *testing.T) {
 	row := createRow(t)
-	colExpr, err := NewColumnExpression(8, VarcharColumnType)
-	require.Nil(t, err)
+	colExpr := NewColumnExpression(8, VarcharColumnType)
 	val, null, err := colExpr.EvalString(row)
 	require.Nil(t, err)
 	require.False(t, null)
@@ -94,8 +85,7 @@ func TestColumnExpressionVarchar(t *testing.T) {
 
 func TestColumnExpressionNullVarchar(t *testing.T) {
 	row := createRow(t)
-	colExpr, err := NewColumnExpression(9, VarcharColumnType)
-	require.Nil(t, err)
+	colExpr := NewColumnExpression(9, VarcharColumnType)
 	_, null, err := colExpr.EvalString(row)
 	require.Nil(t, err)
 	require.True(t, null)
@@ -103,8 +93,7 @@ func TestColumnExpressionNullVarchar(t *testing.T) {
 
 func TestColumnExpressionDecimal(t *testing.T) {
 	row := createRow(t)
-	colExpr, err := NewColumnExpression(10, NewDecimalColumnType(10, 2))
-	require.Nil(t, err)
+	colExpr := NewColumnExpression(10, NewDecimalColumnType(10, 2))
 	val, null, err := colExpr.EvalDecimal(row)
 	require.Nil(t, err)
 	require.False(t, null)
@@ -115,8 +104,7 @@ func TestColumnExpressionDecimal(t *testing.T) {
 
 func TestColumnExpressionNullDecimal(t *testing.T) {
 	row := createRow(t)
-	colExpr, err := NewColumnExpression(11, NewDecimalColumnType(10, 2))
-	require.Nil(t, err)
+	colExpr := NewColumnExpression(11, NewDecimalColumnType(10, 2))
 	_, null, err := colExpr.EvalDecimal(row)
 	require.Nil(t, err)
 	require.True(t, null)
@@ -126,8 +114,7 @@ func createRow(t *testing.T) *Row {
 	t.Helper()
 	decType1 := NewDecimalColumnType(10, 2)
 	colTypes := []ColumnType{TinyIntColumnType, TinyIntColumnType, IntColumnType, IntColumnType, BigIntColumnType, BigIntColumnType, DoubleColumnType, DoubleColumnType, VarcharColumnType, VarcharColumnType, decType1, decType1}
-	rf, err := NewRowsFactory(colTypes)
-	require.Nil(t, err)
+	rf := NewRowsFactory(colTypes)
 	rows := rf.NewRows(1)
 	rows.AppendInt64ToColumn(0, 1)
 	rows.AppendNullToColumn(1)
@@ -149,8 +136,7 @@ func createRow(t *testing.T) *Row {
 
 func TestConstantTinyIntExpression(t *testing.T) {
 	row := createRow(t)
-	expr, err := NewConstantInt(TinyIntColumnType, 100)
-	require.Nil(t, err)
+	expr := NewConstantInt(TinyIntColumnType, 100)
 	val, null, err := expr.EvalInt64(row)
 	require.Nil(t, err)
 	require.False(t, null)
@@ -159,8 +145,7 @@ func TestConstantTinyIntExpression(t *testing.T) {
 
 func TestConstantIntExpression(t *testing.T) {
 	row := createRow(t)
-	expr, err := NewConstantInt(IntColumnType, 101)
-	require.Nil(t, err)
+	expr := NewConstantInt(IntColumnType, 101)
 	val, null, err := expr.EvalInt64(row)
 	require.Nil(t, err)
 	require.False(t, null)
@@ -169,8 +154,7 @@ func TestConstantIntExpression(t *testing.T) {
 
 func TestConstantBigIntExpression(t *testing.T) {
 	row := createRow(t)
-	expr, err := NewConstantInt(BigIntColumnType, 102)
-	require.Nil(t, err)
+	expr := NewConstantInt(BigIntColumnType, 102)
 	val, null, err := expr.EvalInt64(row)
 	require.Nil(t, err)
 	require.False(t, null)
@@ -179,8 +163,7 @@ func TestConstantBigIntExpression(t *testing.T) {
 
 func TestConstantDoubleExpression(t *testing.T) {
 	row := createRow(t)
-	expr, err := NewConstantDouble(DoubleColumnType, 1234.32)
-	require.Nil(t, err)
+	expr := NewConstantDouble(DoubleColumnType, 1234.32)
 	val, null, err := expr.EvalFloat64(row)
 	require.Nil(t, err)
 	require.False(t, null)
@@ -189,8 +172,7 @@ func TestConstantDoubleExpression(t *testing.T) {
 
 func TestConstantStringExpression(t *testing.T) {
 	row := createRow(t)
-	expr, err := NewConstantVarchar(VarcharColumnType, "other-string")
-	require.Nil(t, err)
+	expr := NewConstantVarchar(VarcharColumnType, "other-string")
 	val, null, err := expr.EvalString(row)
 	require.Nil(t, err)
 	require.False(t, null)
@@ -199,10 +181,8 @@ func TestConstantStringExpression(t *testing.T) {
 
 func TestScalarFunctionExpression(t *testing.T) {
 	row := createRow(t)
-	colExpr1, err := NewColumnExpression(0, TinyIntColumnType)
-	require.Nil(t, err)
-	colExpr2, err := NewColumnExpression(2, IntColumnType)
-	require.Nil(t, err)
+	colExpr1 := NewColumnExpression(0, TinyIntColumnType)
+	colExpr2 := NewColumnExpression(2, IntColumnType)
 	expr1, err := NewScalarFunctionExpression(BigIntColumnType, "gt", colExpr2, colExpr1)
 	require.Nil(t, err)
 	val, null, err := expr1.EvalInt64(row)

--- a/common/rows.go
+++ b/common/rows.go
@@ -22,12 +22,9 @@ type RowsFactory struct {
 	ColumnTypes   []ColumnType
 }
 
-func NewRowsFactory(columnTypes []ColumnType) (*RowsFactory, error) {
-	astFieldTypes, err := toAstFieldTypes(columnTypes)
-	if err != nil {
-		return nil, err
-	}
-	return &RowsFactory{astFieldTypes: astFieldTypes, ColumnTypes: columnTypes}, nil
+func NewRowsFactory(columnTypes []ColumnType) *RowsFactory {
+	astFieldTypes := toAstFieldTypes(columnTypes)
+	return &RowsFactory{astFieldTypes: astFieldTypes, ColumnTypes: columnTypes}
 }
 
 func (rf *RowsFactory) NewRows(capacity int) *Rows {
@@ -35,16 +32,13 @@ func (rf *RowsFactory) NewRows(capacity int) *Rows {
 	return &Rows{chunk: ch}
 }
 
-func toAstFieldTypes(columnTypes []ColumnType) ([]*types.FieldType, error) {
+func toAstFieldTypes(columnTypes []ColumnType) []*types.FieldType {
 	var astFieldTypes []*types.FieldType
 	for _, colType := range columnTypes {
-		astColType, err := ConvertPranaTypeToTiDBType(colType)
-		if err != nil {
-			return nil, err
-		}
+		astColType := ConvertPranaTypeToTiDBType(colType)
 		astFieldTypes = append(astFieldTypes, astColType)
 	}
-	return astFieldTypes, nil
+	return astFieldTypes
 }
 
 func (r *Rows) GetRow(rowIndex int) Row {

--- a/common/rows_test.go
+++ b/common/rows_test.go
@@ -10,8 +10,7 @@ import (
 func TestRows(t *testing.T) {
 	decType1 := NewDecimalColumnType(10, 2)
 	colTypes := []ColumnType{TinyIntColumnType, IntColumnType, BigIntColumnType, DoubleColumnType, VarcharColumnType, decType1}
-	rf, err := NewRowsFactory(colTypes)
-	require.Nil(t, err)
+	rf := NewRowsFactory(colTypes)
 	rows := rf.NewRows(1)
 	rowCount := 10
 	for i := 0; i < rowCount; i++ {

--- a/parplan/infoschema.go
+++ b/parplan/infoschema.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	tidbTable "github.com/pingcap/tidb/table"
 	tidbTypes "github.com/pingcap/tidb/types"
+
 	"github.com/squareup/pranadb/common"
 )
 
@@ -34,7 +35,7 @@ type iSSchemaInfo struct {
 	TablesInfos map[string]*common.TableInfo
 }
 
-func schemaToInfoSchema(schema *common.Schema) (infoschema.InfoSchema, error) {
+func schemaToInfoSchema(schema *common.Schema) infoschema.InfoSchema {
 
 	tableInfos := make(map[string]*common.TableInfo)
 	for mvName, mv := range schema.Mvs {
@@ -58,10 +59,7 @@ func schemaToInfoSchema(schema *common.Schema) (infoschema.InfoSchema, error) {
 		var columns []*model.ColumnInfo
 		for columnIndex, columnType := range tableInfo.ColumnTypes {
 
-			colType, err := common.ConvertPranaTypeToTiDBType(columnType)
-			if err != nil {
-				return nil, err
-			}
+			colType := common.ConvertPranaTypeToTiDBType(columnType)
 
 			col := &model.ColumnInfo{
 				State:     model.StatePublic,
@@ -132,7 +130,7 @@ func schemaToInfoSchema(schema *common.Schema) (infoschema.InfoSchema, error) {
 	}
 	result.schemaMap[schemaInfo.SchemaName] = tableNames
 
-	return result, nil
+	return result
 }
 
 func (pis *pranaInfoSchema) SchemaByName(schema model.CIStr) (val *model.DBInfo, ok bool) {

--- a/parplan/planner.go
+++ b/parplan/planner.go
@@ -2,8 +2,9 @@ package parplan
 
 import (
 	"context"
-	"github.com/squareup/pranadb/sessctx"
 	"math"
+
+	"github.com/squareup/pranadb/sessctx"
 
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/tidb/infoschema"
@@ -11,6 +12,7 @@ import (
 	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util/hint"
+
 	"github.com/squareup/pranadb/common"
 )
 
@@ -34,13 +36,13 @@ func (p *Planner) QueryToPlan(schema *common.Schema, query string, pullQuery boo
 	if err != nil {
 		return nil, err
 	}
-	is, err := schemaToInfoSchema(schema)
+	is := schemaToInfoSchema(schema)
 	if err != nil {
 		return nil, err
 	}
 	ctx := context.TODO()
 	sessCtx := sessctx.NewSessionContext(is, pullQuery)
-	//TODO doesn't seem to work if there are prepared statement markers
+	// TODO doesn't seem to work if there are prepared statement markers
 	err = core.Preprocess(sessCtx, stmt)
 	if err != nil {
 		return nil, err

--- a/pull/exec/projection.go
+++ b/pull/exec/projection.go
@@ -12,10 +12,7 @@ type PullProjection struct {
 }
 
 func NewPullProjection(colNames []string, colTypes []common.ColumnType, projColumns []*common.Expression) (*PullProjection, error) {
-	rf, err := common.NewRowsFactory(colTypes)
-	if err != nil {
-		return nil, err
-	}
+	rf := common.NewRowsFactory(colTypes)
 	base := pullExecutorBase{
 		colNames:    colNames,
 		colTypes:    colTypes,

--- a/pull/exec/remote_executor.go
+++ b/pull/exec/remote_executor.go
@@ -17,11 +17,8 @@ type RemoteExecutor struct {
 	RemoteDag      PullExecutor
 }
 
-func NewRemoteExecutor(colTypes []common.ColumnType, remoteDag PullExecutor, schemaName string, query string, queryID string, nodeIDs []int, cluster cluster.Cluster) (*RemoteExecutor, error) {
-	rf, err := common.NewRowsFactory(colTypes)
-	if err != nil {
-		return nil, err
-	}
+func NewRemoteExecutor(colTypes []common.ColumnType, remoteDag PullExecutor, schemaName string, query string, queryID string, nodeIDs []int, cluster cluster.Cluster) *RemoteExecutor {
+	rf := common.NewRowsFactory(colTypes)
 	base := pullExecutorBase{
 		colTypes:    colTypes,
 		rowsFactory: rf,
@@ -35,7 +32,7 @@ func NewRemoteExecutor(colTypes []common.ColumnType, remoteDag PullExecutor, sch
 		RemoteDag:        remoteDag,
 	}
 	pg.clusterGetters = createGetters(nodeIDs, &pg)
-	return &pg, nil
+	return &pg
 }
 
 func createGetters(nodeIDs []int, gatherer *RemoteExecutor) []*clusterGetter {

--- a/pull/exec/select.go
+++ b/pull/exec/select.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"errors"
+
 	"github.com/squareup/pranadb/common"
 )
 
@@ -10,11 +11,8 @@ type PullSelect struct {
 	predicates []*common.Expression
 }
 
-func NewPullSelect(colNames []string, colTypes []common.ColumnType, predicates []*common.Expression) (*PullSelect, error) {
-	rf, err := common.NewRowsFactory(colTypes)
-	if err != nil {
-		return nil, err
-	}
+func NewPullSelect(colNames []string, colTypes []common.ColumnType, predicates []*common.Expression) *PullSelect {
+	rf := common.NewRowsFactory(colTypes)
 	base := pullExecutorBase{
 		colNames:    colNames,
 		colTypes:    colTypes,
@@ -23,7 +21,7 @@ func NewPullSelect(colNames []string, colTypes []common.ColumnType, predicates [
 	return &PullSelect{
 		pullExecutorBase: base,
 		predicates:       predicates,
-	}, nil
+	}
 }
 
 func (p *PullSelect) GetRows(limit int) (rows *common.Rows, err error) {

--- a/pull/exec/table_scan.go
+++ b/pull/exec/table_scan.go
@@ -12,11 +12,8 @@ type PullTableScan struct {
 	storage   storage.Storage
 }
 
-func NewPullTableScan(colTypes []common.ColumnType, tableInfo *common.TableInfo, storage storage.Storage) (*PullTableScan, error) {
-	rf, err := common.NewRowsFactory(colTypes)
-	if err != nil {
-		return nil, err
-	}
+func NewPullTableScan(colTypes []common.ColumnType, tableInfo *common.TableInfo, storage storage.Storage) *PullTableScan {
+	rf := common.NewRowsFactory(colTypes)
 	base := pullExecutorBase{
 		colTypes:    colTypes,
 		rowsFactory: rf,
@@ -25,7 +22,7 @@ func NewPullTableScan(colTypes []common.ColumnType, tableInfo *common.TableInfo,
 		pullExecutorBase: base,
 		tableInfo:        tableInfo,
 		storage:          storage,
-	}, nil
+	}
 }
 
 func (t *PullTableScan) SetSchema(colNames []string, colTypes []common.ColumnType, keyCols []int) {

--- a/pull/exec_builder.go
+++ b/pull/exec_builder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/pingcap/tidb/planner/core"
+
 	"github.com/squareup/pranadb/common"
 	"github.com/squareup/pranadb/pull/exec"
 )
@@ -43,10 +44,7 @@ func (p *PullEngine) buildPullDAG(plan core.PhysicalPlan, schema *common.Schema,
 	colNames := make([]string, 0, len(cols))
 	for _, col := range cols {
 		colType := col.GetType()
-		pranaType, err := common.ConvertTiDBTypeToPranaType(colType)
-		if err != nil {
-			return nil, err
-		}
+		pranaType := common.ConvertTiDBTypeToPranaType(colType)
 		colTypes = append(colTypes, pranaType)
 		colNames = append(colNames, col.OrigName)
 	}
@@ -67,7 +65,7 @@ func (p *PullEngine) buildPullDAG(plan core.PhysicalPlan, schema *common.Schema,
 		for _, expr := range op.Conditions {
 			exprs = append(exprs, common.NewExpression(expr))
 		}
-		executor, err = exec.NewPullSelect(colNames, colTypes, exprs)
+		executor = exec.NewPullSelect(colNames, colTypes, exprs)
 		if err != nil {
 			return nil, err
 		}
@@ -92,7 +90,7 @@ func (p *PullEngine) buildPullDAG(plan core.PhysicalPlan, schema *common.Schema,
 		for nodeID := range clusterInfo.NodeInfos {
 			nodeIDs = append(nodeIDs, nodeID)
 		}
-		executor, err = exec.NewRemoteExecutor(colTypes, remoteDag, schema.Name, query, queryID, nodeIDs, p.cluster)
+		executor = exec.NewRemoteExecutor(colTypes, remoteDag, schema.Name, query, queryID, nodeIDs, p.cluster)
 		if err != nil {
 			return nil, err
 		}
@@ -109,7 +107,7 @@ func (p *PullEngine) buildPullDAG(plan core.PhysicalPlan, schema *common.Schema,
 		} else {
 			t = mv.TableInfo
 		}
-		executor, err = exec.NewPullTableScan(colTypes, t, p.storage)
+		executor = exec.NewPullTableScan(colTypes, t, p.storage)
 		if err != nil {
 			return nil, err
 		}

--- a/push/exec/aggregator.go
+++ b/push/exec/aggregator.go
@@ -28,10 +28,7 @@ type AggregateFunctionInfo struct {
 
 func NewAggregator(colNames []string, colTypes []common.ColumnType, pkCols []int, aggFunctions []*AggregateFunctionInfo, aggTableInfo *common.TableInfo, groupByCols []int,
 	storage storage.Storage, sharder *sharder.Sharder) (*Aggregator, error) {
-	rf, err := common.NewRowsFactory(colTypes)
-	if err != nil {
-		return nil, err
-	}
+	rf := common.NewRowsFactory(colTypes)
 	pushBase := pushExecutorBase{
 		colNames:    colNames,
 		colTypes:    colTypes,

--- a/push/exec/project_test.go
+++ b/push/exec/project_test.go
@@ -22,7 +22,7 @@ func TestProjectionOneCol(t *testing.T) {
 	}
 	expectedColTypes := []common.ColumnType{common.VarcharColumnType}
 	expectedColNames := []string{"location"}
-	testProject(t, inpRows, expectedRows, expectedColNames, expectedColTypes, colExpression(t, 1))
+	testProject(t, inpRows, expectedRows, expectedColNames, expectedColTypes, colExpression(1))
 }
 
 func TestProjectionAllCols(t *testing.T) {
@@ -36,7 +36,7 @@ func TestProjectionAllCols(t *testing.T) {
 		{2, "london", 35.1, "9.32"},
 		{3, "los angeles", 20.6, "11.75"},
 	}
-	testProject(t, inpRows, expectedRows, colNames, colTypes, colExpression(t, 0), colExpression(t, 1), colExpression(t, 2), colExpression(t, 3))
+	testProject(t, inpRows, expectedRows, colNames, colTypes, colExpression(0), colExpression(1), colExpression(2), colExpression(3))
 }
 
 func TestProjectionAllColsReverseOrder(t *testing.T) {
@@ -52,7 +52,7 @@ func TestProjectionAllColsReverseOrder(t *testing.T) {
 	}
 	columnNames := []string{"temperature", "location", "sensor_id"}
 	columnTypes := []common.ColumnType{common.NewDecimalColumnType(10, 2), common.DoubleColumnType, common.VarcharColumnType, common.BigIntColumnType}
-	testProject(t, inpRows, expectedRows, columnNames, columnTypes, colExpression(t, 3), colExpression(t, 2), colExpression(t, 1), colExpression(t, 0))
+	testProject(t, inpRows, expectedRows, columnNames, columnTypes, colExpression(3), colExpression(2), colExpression(1), colExpression(0))
 }
 
 func TestProjectionNonColExpression(t *testing.T) {
@@ -66,18 +66,16 @@ func TestProjectionNonColExpression(t *testing.T) {
 		{2, "london", 36.1, "9.32"},
 		{3, "los angeles", 21.6, "11.75"},
 	}
-	con, err := common.NewConstantInt(common.BigIntColumnType, 1)
-	require.Nil(t, err)
+	con := common.NewConstantInt(common.BigIntColumnType, 1)
 	// Add one to column 2
-	f, err := common.NewScalarFunctionExpression(colTypes[2], "plus", colExpression(t, 2), con)
+	f, err := common.NewScalarFunctionExpression(colTypes[2], "plus", colExpression(2), con)
 	require.Nil(t, err)
-	testProject(t, inpRows, expectedRows, colNames, colTypes, colExpression(t, 0), colExpression(t, 1), f, colExpression(t, 3))
+	testProject(t, inpRows, expectedRows, colNames, colTypes, colExpression(0), colExpression(1), f, colExpression(3))
 }
 
 func testProject(t *testing.T, inputRows [][]interface{}, expectedRows [][]interface{}, expectedColNames []string, expectedColTypes []common.ColumnType, projExprs ...*common.Expression) {
 	t.Helper()
-	proj, err := NewPushProjection(expectedColNames, expectedColTypes, projExprs)
-	require.Nil(t, err)
+	proj := NewPushProjection(expectedColNames, expectedColTypes, projExprs)
 	execCtx := &ExecutionContext{
 		WriteBatch: storage.NewWriteBatch(1),
 	}
@@ -85,7 +83,7 @@ func testProject(t *testing.T, inputRows [][]interface{}, expectedRows [][]inter
 	proj.SetParent(rg)
 
 	inpRows := toRows(t, inputRows, colTypes)
-	err = proj.HandleRows(inpRows, execCtx)
+	err := proj.HandleRows(inpRows, execCtx)
 	require.Nil(t, err)
 
 	gathered := rg.Rows

--- a/push/exec/projection.go
+++ b/push/exec/projection.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"fmt"
+
 	"github.com/squareup/pranadb/common"
 )
 
@@ -11,11 +12,8 @@ type PushProjection struct {
 	invisibleKeyColumns []int
 }
 
-func NewPushProjection(colNames []string, colTypes []common.ColumnType, projColumns []*common.Expression) (*PushProjection, error) {
-	rf, err := common.NewRowsFactory(colTypes)
-	if err != nil {
-		return nil, err
-	}
+func NewPushProjection(colNames []string, colTypes []common.ColumnType, projColumns []*common.Expression) *PushProjection {
+	rf := common.NewRowsFactory(colTypes)
 	pushBase := pushExecutorBase{
 		colNames:    colNames,
 		colTypes:    colTypes,
@@ -24,7 +22,7 @@ func NewPushProjection(colNames []string, colTypes []common.ColumnType, projColu
 	return &PushProjection{
 		pushExecutorBase: pushBase,
 		projColumns:      projColumns,
-	}, nil
+	}
 }
 
 func (p *PushProjection) ReCalcSchemaFromChildren() {

--- a/push/exec/select.go
+++ b/push/exec/select.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"errors"
+
 	"github.com/squareup/pranadb/common"
 )
 
@@ -10,11 +11,8 @@ type PushSelect struct {
 	predicates []*common.Expression
 }
 
-func NewPushSelect(colNames []string, colTypes []common.ColumnType, predicates []*common.Expression) (*PushSelect, error) {
-	rf, err := common.NewRowsFactory(colTypes)
-	if err != nil {
-		return nil, err
-	}
+func NewPushSelect(colNames []string, colTypes []common.ColumnType, predicates []*common.Expression) *PushSelect {
+	rf := common.NewRowsFactory(colTypes)
 	pushBase := pushExecutorBase{
 		colNames:    colNames,
 		colTypes:    colTypes,
@@ -23,7 +21,7 @@ func NewPushSelect(colNames []string, colTypes []common.ColumnType, predicates [
 	return &PushSelect{
 		pushExecutorBase: pushBase,
 		predicates:       predicates,
-	}, nil
+	}
 }
 
 func (p *PushSelect) ReCalcSchemaFromChildren() {

--- a/push/exec/select_test.go
+++ b/push/exec/select_test.go
@@ -18,7 +18,7 @@ func TestSelectOneRow(t *testing.T) {
 	expectedRows := [][]interface{}{
 		{2, "london", 35.1, "9.32"},
 	}
-	testSelect(t, inpRows, expectedRows, "gt", colExpression(t, 2), constDoubleExpression(t, 2, 28.0))
+	testSelect(t, inpRows, expectedRows, "gt", colExpression(2), constDoubleExpression(2, 28.0))
 }
 
 func TestSelectAllRows(t *testing.T) {
@@ -32,7 +32,7 @@ func TestSelectAllRows(t *testing.T) {
 		{2, "london", 35.1, "9.32"},
 		{3, "los angeles", 20.6, "11.75"},
 	}
-	testSelect(t, inpRows, expectedRows, "gt", colExpression(t, 2), constDoubleExpression(t, 2, 15.0))
+	testSelect(t, inpRows, expectedRows, "gt", colExpression(2), constDoubleExpression(2, 15.0))
 }
 
 func TestSelectNoRows(t *testing.T) {
@@ -42,14 +42,14 @@ func TestSelectNoRows(t *testing.T) {
 		{3, "los angeles", 20.6, "11.75"},
 	}
 	var expectedRows [][]interface{}
-	testSelect(t, inpRows, expectedRows, "gt", colExpression(t, 2), constDoubleExpression(t, 2, 40.0))
+	testSelect(t, inpRows, expectedRows, "gt", colExpression(2), constDoubleExpression(2, 40.0))
 }
 
 func testSelect(t *testing.T, inputRows [][]interface{}, expectedRows [][]interface{}, funcName string, funcArgs ...*common.Expression) {
 	t.Helper()
 	predicate, err := common.NewScalarFunctionExpression(colTypes[2], funcName, funcArgs...)
 	require.Nil(t, err)
-	sel, err := NewPushSelect(colNames, colTypes, []*common.Expression{predicate})
+	sel := NewPushSelect(colNames, colTypes, []*common.Expression{predicate})
 	require.Nil(t, err)
 	execCtx := &ExecutionContext{
 		WriteBatch: storage.NewWriteBatch(1),

--- a/push/exec/table_exec.go
+++ b/push/exec/table_exec.go
@@ -1,10 +1,11 @@
 package exec
 
 import (
+	"log"
+
 	"github.com/squareup/pranadb/common"
 	"github.com/squareup/pranadb/storage"
 	"github.com/squareup/pranadb/table"
-	"log"
 )
 
 // TableExecutor updates the changes into the associated table - used to persist state
@@ -16,11 +17,8 @@ type TableExecutor struct {
 	store          storage.Storage
 }
 
-func NewTableExecutor(colTypes []common.ColumnType, tableInfo *common.TableInfo, store storage.Storage) (*TableExecutor, error) {
-	rf, err := common.NewRowsFactory(colTypes)
-	if err != nil {
-		return nil, err
-	}
+func NewTableExecutor(colTypes []common.ColumnType, tableInfo *common.TableInfo, store storage.Storage) *TableExecutor {
+	rf := common.NewRowsFactory(colTypes)
 	pushBase := pushExecutorBase{
 		colTypes:    colTypes,
 		rowsFactory: rf,
@@ -29,7 +27,7 @@ func NewTableExecutor(colTypes []common.ColumnType, tableInfo *common.TableInfo,
 		pushExecutorBase: pushBase,
 		tableInfo:        tableInfo,
 		store:            store,
-	}, nil
+	}
 }
 
 func (t *TableExecutor) ReCalcSchemaFromChildren() {

--- a/push/exec/utils_for_test.go
+++ b/push/exec/utils_for_test.go
@@ -15,27 +15,22 @@ var colTypes = []common.ColumnType{common.BigIntColumnType, common.VarcharColumn
 
 func toRows(t *testing.T, rows [][]interface{}, colTypes []common.ColumnType) *common.Rows {
 	t.Helper()
-	rf, err := common.NewRowsFactory(colTypes)
-	require.Nil(t, err)
+	rf := common.NewRowsFactory(colTypes)
 	r := rf.NewRows(len(rows))
 	for _, row := range rows {
-		err = common.AppendRow(t, r, colTypes, row...)
+		err := common.AppendRow(t, r, colTypes, row...)
 		require.NoError(t, err)
 	}
 	return r
 }
 
-func colExpression(t *testing.T, colIndex int) *common.Expression {
-	t.Helper()
-	col, err := common.NewColumnExpression(colIndex, colTypes[colIndex])
-	require.Nil(t, err)
+func colExpression(colIndex int) *common.Expression {
+	col := common.NewColumnExpression(colIndex, colTypes[colIndex])
 	return col
 }
 
-func constDoubleExpression(t *testing.T, colIndex int, val float64) *common.Expression {
-	t.Helper()
-	con, err := common.NewConstantDouble(colTypes[colIndex], val)
-	require.Nil(t, err)
+func constDoubleExpression(colIndex int, val float64) *common.Expression {
+	con := common.NewConstantDouble(colTypes[colIndex], val)
 	return con
 }
 

--- a/push/mover_test.go
+++ b/push/mover_test.go
@@ -47,8 +47,7 @@ func TestTransferData(t *testing.T) {
 	numRows := 10
 	colTypes := []common.ColumnType{common.BigIntColumnType, common.VarcharColumnType}
 	localShardID := uint64(1)
-	rf, err := common.NewRowsFactory(colTypes)
-	require.Nil(t, err)
+	rf := common.NewRowsFactory(colTypes)
 	rows := queueRows(t, numRows, colTypes, rf, shard, pe, localShardID, stor, localShardID)
 
 	keyStartPrefix := createForwarderKey(localShardID)
@@ -96,8 +95,7 @@ func TestHandleReceivedRows(t *testing.T) {
 	numRows := 10
 	colTypes := []common.ColumnType{common.BigIntColumnType, common.VarcharColumnType}
 
-	rf, err := common.NewRowsFactory(colTypes)
-	require.Nil(t, err)
+	rf := common.NewRowsFactory(colTypes)
 
 	clustInfo, err := clus.GetClusterInfo()
 	require.Nil(t, err)
@@ -235,8 +233,7 @@ func TestDedupOfForwards(t *testing.T) {
 	numRows := 10
 	colTypes := []common.ColumnType{common.BigIntColumnType, common.VarcharColumnType}
 	localShardID := uint64(1)
-	rf, err := common.NewRowsFactory(colTypes)
-	require.Nil(t, err)
+	rf := common.NewRowsFactory(colTypes)
 	rows := queueRows(t, numRows, colTypes, rf, shard, pe, localShardID, stor, localShardID)
 	remoteShardsIds := make(map[uint64]bool)
 	for _, row := range rows {
@@ -338,8 +335,7 @@ func testQueueForRemoteSend(t *testing.T, startSequence int, store storage.Stora
 	localShardID := uint64(1)
 
 	numRows := 10
-	rf, err := common.NewRowsFactory(colTypes)
-	require.NoError(t, err)
+	rf := common.NewRowsFactory(colTypes)
 
 	rows := queueRows(t, numRows, colTypes, rf, shard, pe, localShardID, store, localShardID)
 

--- a/push/mv.go
+++ b/push/mv.go
@@ -31,7 +31,7 @@ func (p *PushEngine) CreateMaterializedView(schema *common.Schema, mvName string
 		Query:      query,
 		TableInfo:  &tableInfo,
 	}
-	tableNode, err := exec.NewTableExecutor(dag.ColTypes(), &tableInfo, p.storage)
+	tableNode := exec.NewTableExecutor(dag.ColTypes(), &tableInfo, p.storage)
 	if err != nil {
 		return nil, err
 	}

--- a/push/source.go
+++ b/push/source.go
@@ -19,10 +19,7 @@ func (p *PushEngine) CreateSource(sourceInfo *common.SourceInfo) error {
 
 	colTypes := sourceInfo.TableInfo.ColumnTypes
 
-	tableExecutor, err := exec.NewTableExecutor(colTypes, sourceInfo.TableInfo, p.storage)
-	if err != nil {
-		return err
-	}
+	tableExecutor := exec.NewTableExecutor(colTypes, sourceInfo.TableInfo, p.storage)
 
 	p.lock.Lock()
 	defer p.lock.Unlock()
@@ -33,10 +30,7 @@ func (p *PushEngine) CreateSource(sourceInfo *common.SourceInfo) error {
 		engine:        p,
 	}
 
-	rf, err := common.NewRowsFactory(colTypes)
-	if err != nil {
-		return err
-	}
+	rf := common.NewRowsFactory(colTypes)
 	rc := &remoteConsumer{
 		RowsFactory: rf,
 		ColTypes:    colTypes,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -26,7 +26,7 @@ func TestCreateMaterializedView(t *testing.T) {
 	err = ce.CreateMaterializedView("test", "max_readings", query)
 	require.Nil(t, err)
 
-	rf, err := common.NewRowsFactory(colTypes)
+	rf := common.NewRowsFactory(colTypes)
 	require.Nil(t, err)
 
 	rows := rf.NewRows(10)
@@ -49,7 +49,7 @@ func TestCreateMaterializedView(t *testing.T) {
 	require.True(t, ok)
 
 	expectedColTypes := []common.ColumnType{common.BigIntColumnType, common.DoubleColumnType}
-	expectedRf, err := common.NewRowsFactory(expectedColTypes)
+	expectedRf := common.NewRowsFactory(expectedColTypes)
 	require.Nil(t, err)
 	expectedRows := expectedRf.NewRows(10)
 	err = common.AppendRow(t, expectedRows, expectedColTypes, 1, 25.5)
@@ -74,7 +74,7 @@ func TestExecutePullQuery(t *testing.T) {
 	err = ce.CreateSource("test", "sensor_readings", []string{"sensor_id", "location", "temperature"}, colTypes, []int{0}, nil)
 	require.Nil(t, err)
 
-	rf, err := common.NewRowsFactory(colTypes)
+	rf := common.NewRowsFactory(colTypes)
 	require.Nil(t, err)
 	rows := rf.NewRows(10)
 	err = common.AppendRow(t, rows, colTypes, 1, "wincanton", 25.5)


### PR DESCRIPTION
This simplifies calling signatures quite a bit in numerous places. It is
a 100% mechanical refactoring.

The rationale here is that any type conversion failure will be our
error, not an end user error, so there's no benefit in returning it to
the user as they can't do anything about it. This is a common pattern in
Go. For example the "reflect" package returns no errors, requiring the
developer to correctly use the library and panicking on misuse.