### PR TITLE
Skip big tests -f `go test -short` is used.

### DIFF
--- a/cluster/dragon/dragon_test.go
+++ b/cluster/dragon/dragon_test.go
@@ -2,12 +2,8 @@ package dragon
 
 import (
 	"errors"
+	"flag"
 	"fmt"
-	"github.com/squareup/pranadb/cluster"
-	"github.com/squareup/pranadb/common"
-	"github.com/squareup/pranadb/common/commontest"
-	"github.com/squareup/pranadb/protos/squareup/cash/pranadb/notifications"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"log"
 	"math/rand"
@@ -15,6 +11,13 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/squareup/pranadb/cluster"
+	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/common/commontest"
+	"github.com/squareup/pranadb/protos/squareup/cash/pranadb/notifications"
 )
 
 var dragonCluster []cluster.Cluster
@@ -24,6 +27,11 @@ const (
 )
 
 func TestMain(m *testing.M) {
+	flag.Parse()
+	if testing.Short() {
+		log.Println("-short: skipped")
+		return
+	}
 	dataDir, err := ioutil.TempDir("", "dragon-test")
 	if err != nil {
 		panic("failed to create temp dir")

--- a/push/mover_test.go
+++ b/push/mover_test.go
@@ -2,8 +2,9 @@ package push
 
 import (
 	"fmt"
-	"github.com/squareup/pranadb/common/commontest"
 	"testing"
+
+	"github.com/squareup/pranadb/common/commontest"
 
 	"github.com/stretchr/testify/require"
 
@@ -365,6 +366,9 @@ func testQueueForRemoteSend(t *testing.T, startSequence int, store cluster.Clust
 
 func startup(t *testing.T) (cluster.Cluster, *sharder.Sharder, *PushEngine) {
 	t.Helper()
+	if testing.Short() {
+		t.Skip("-short: skipped")
+	}
 	clus := cluster.NewFakeCluster(1, 10)
 	shard := sharder.NewSharder(clus)
 	pe := NewPushEngine(clus, shard)

--- a/sqltest/sql_test.go
+++ b/sqltest/sql_test.go
@@ -3,12 +3,6 @@ package sqltest
 import (
 	"bufio"
 	"fmt"
-	"github.com/squareup/pranadb/common"
-	"github.com/squareup/pranadb/parplan"
-	"github.com/squareup/pranadb/server"
-	"github.com/squareup/pranadb/sess"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 	"io/ioutil"
 	"log"
 	"math/rand"
@@ -18,6 +12,14 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/parplan"
+	"github.com/squareup/pranadb/server"
+	"github.com/squareup/pranadb/sess"
 )
 
 type sqlTestsuite struct {
@@ -42,6 +44,9 @@ func TestSqlFakeCluster(t *testing.T) {
 }
 
 func TestSqlClustered(t *testing.T) {
+	if testing.Short() {
+		t.Skip("-short: skipped")
+	}
 	testSQL(t, false, 3)
 }
 


### PR DESCRIPTION
This drops project-wide test runs from ~2 minutes to ~2 seconds.