### PR TITLE
AST tweaks for TINY/BIGINT and CREATE MV

### DIFF
--- a/command/command_test.go
+++ b/command/command_test.go
@@ -33,14 +33,14 @@ func TestCommandExecutorExecutePullQuery(t *testing.T) {
 	}{
 		{name: "CreateSource", query: `
 			create source sensor_readings(
-				sensor_id big int,
+				sensor_id bigint,
 				location varchar,
 				temperature double,
 				primary key (sensor_id)
 			)
 		`, rows: exec.Empty},
 		{name: "CreateMV", query: `
-			create materialized view test
+			create materialized view test as
 				select sensor_id, max(temperature)
 				from test.sensor_readings
 				where location='wincanton' group by sensor_id

--- a/command/parser/ast.go
+++ b/command/parser/ast.go
@@ -37,7 +37,7 @@ func (r *Ref) String() string {
 
 // CreateMaterializedView statement.
 type CreateMaterializedView struct {
-	Name  *Ref      `@@`
+	Name  *Ref      `@@ "AS"`
 	Query *RawQuery `@@`
 }
 
@@ -45,8 +45,8 @@ type ColumnDef struct {
 	Pos lexer.Position
 
 	Name       string      `@Ident`
-	Type       common.Type `@(("TINY"|"BIG")? ("VARCHAR"|"INT"|"TIMESTAMP"|"DOUBLE"))` // Conversion done by common.Type.Capture()
-	Parameters []int       `("(" @Number ("," @Number)* ")")?`                         // Optional parameters to the type(x [, x, ...])
+	Type       common.Type `@(("VARCHAR"|"TINYINT"|"BIGINT"|"TIMESTAMP"|"DOUBLE"))` // Conversion done by common.Type.Capture()
+	Parameters []int       `("(" @Number ("," @Number)* ")")?`                      // Optional parameters to the type(x [, x, ...])
 }
 
 func (c *ColumnDef) ToColumnType() (common.ColumnType, error) {

--- a/command/parser/ast_test.go
+++ b/command/parser/ast_test.go
@@ -17,20 +17,20 @@ func TestParse(t *testing.T) {
 	}{
 		{"Select", "SELECT * FROM table WHERE foo = `bar`",
 			&AST{Select: "SELECT * FROM table WHERE foo = `bar`"}, ""},
-		{"CreateMV", `CREATE MATERIALIZED VIEW myview SELECT * FROM table`, &AST{
+		{"CreateMV", `CREATE MATERIALIZED VIEW myview AS SELECT * FROM table`, &AST{
 			Create: &Create{
 				MaterializedView: &CreateMaterializedView{
 					Name: &Ref{Path: []string{"myview"}},
 					Query: &RawQuery{
 						Tokens: []lexer.Token{
-							{Type: -6, Value: " ", Pos: lexer.Position{Offset: 31, Line: 1, Column: 32}},
-							{Type: -2, Value: "SELECT", Pos: lexer.Position{Offset: 32, Line: 1, Column: 33}},
-							{Type: -6, Value: " ", Pos: lexer.Position{Offset: 38, Line: 1, Column: 39}},
-							{Type: -5, Value: "*", Pos: lexer.Position{Offset: 39, Line: 1, Column: 40}},
-							{Type: -6, Value: " ", Pos: lexer.Position{Offset: 40, Line: 1, Column: 41}},
-							{Type: -2, Value: "FROM", Pos: lexer.Position{Offset: 41, Line: 1, Column: 42}},
-							{Type: -6, Value: " ", Pos: lexer.Position{Offset: 45, Line: 1, Column: 46}},
-							{Type: -2, Value: "table", Pos: lexer.Position{Offset: 46, Line: 1, Column: 47}},
+							{Type: -6, Value: " ", Pos: lexer.Position{Offset: 34, Line: 1, Column: 35}},
+							{Type: -2, Value: "SELECT", Pos: lexer.Position{Offset: 35, Line: 1, Column: 36}},
+							{Type: -6, Value: " ", Pos: lexer.Position{Offset: 41, Line: 1, Column: 42}},
+							{Type: -5, Value: "*", Pos: lexer.Position{Offset: 42, Line: 1, Column: 43}},
+							{Type: -6, Value: " ", Pos: lexer.Position{Offset: 43, Line: 1, Column: 44}},
+							{Type: -2, Value: "FROM", Pos: lexer.Position{Offset: 44, Line: 1, Column: 45}},
+							{Type: -6, Value: " ", Pos: lexer.Position{Offset: 48, Line: 1, Column: 49}},
+							{Type: -2, Value: "table", Pos: lexer.Position{Offset: 49, Line: 1, Column: 50}},
 						},
 					},
 				},

--- a/common/meta.go
+++ b/common/meta.go
@@ -24,11 +24,11 @@ const (
 func (t *Type) Capture(tokens []string) error {
 	text := strings.ToUpper(strings.Join(tokens, " "))
 	switch text {
-	case "TINY INT":
+	case "TINYINT":
 		*t = TypeTinyInt
 	case "INT":
 		*t = TypeInt
-	case "BIG INT":
+	case "BIGINT":
 		*t = TypeBigInt
 	case "VARCHAR":
 		*t = TypeVarchar

--- a/sqltest/testdata/simple_test_out.txt
+++ b/sqltest/testdata/simple_test_out.txt
@@ -1,11 +1,11 @@
 create source sensor_readings(
-    sensor_id big int,
+    sensor_id bigint,
     location varchar,
     temperature double,
     primary key (sensor_id)
 );
 Ok
-create materialized view wincanton_readings
+create materialized view wincanton_readings as
     select sensor_id, location, temperature
     from sensor_readings
     where location='wincanton';

--- a/sqltest/testdata/simple_test_script.txt
+++ b/sqltest/testdata/simple_test_script.txt
@@ -1,13 +1,13 @@
 -- Test script;
 
 create source sensor_readings(
-    sensor_id big int,
+    sensor_id bigint,
     location varchar,
     temperature double,
     primary key (sensor_id)
 );
 
-create materialized view wincanton_readings
+create materialized view wincanton_readings as
     select sensor_id, location, temperature
     from sensor_readings
     where location='wincanton';


### PR DESCRIPTION
For MySQL compatibility...

* `TINY INT` and `BIG INT` are now `TINYINT` and `BIGINT`
* Added an `AS` into `CREATE MATERIALIZED VIEW <name> AS SELECT`