### PR TITLE
load sources on cluster restart

### DIFF
--- a/meta/encode.go
+++ b/meta/encode.go
@@ -8,6 +8,11 @@ import (
 
 var tableInfoRowsFactory = common.NewRowsFactory(SchemaTableInfo.ColumnTypes)
 
+const (
+	TableKindSource           = "source"
+	TableKindMaterializedView = "materialized_view"
+)
+
 // EncodeSourceInfoToRow encodes a common.SourceInfo into a database row.
 func EncodeSourceInfoToRow(info *common.SourceInfo) *common.Row {
 	rows := tableInfoRowsFactory.NewRows(1)

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -45,12 +45,10 @@ func NewController(store cluster.Cluster) *Controller {
 func (c *Controller) Start() error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	if !c.started {
+	if c.started {
 		return nil
 	}
-	if err := c.loadSchemas(); err != nil {
-		return err
-	}
+	c.registerSystemSchema()
 	c.started = true
 	return nil
 }
@@ -62,10 +60,6 @@ func (c *Controller) Stop() error {
 		return nil
 	}
 	c.started = false
-	return nil
-}
-
-func (c *Controller) loadSchemas() error {
 	return nil
 }
 

--- a/meta/schema/loader.go
+++ b/meta/schema/loader.go
@@ -1,0 +1,62 @@
+package schema
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/squareup/pranadb/command"
+	"github.com/squareup/pranadb/meta"
+	"github.com/squareup/pranadb/push"
+)
+
+// Loader is a service that loads existing table schemas from disk and applies them to the metadata
+// controller and the push engine.
+type Loader struct {
+	meta       *meta.Controller
+	executor   *command.Executor
+	pushEngine *push.PushEngine
+}
+
+func NewLoader(m *meta.Controller, exec *command.Executor, push *push.PushEngine) *Loader {
+	return &Loader{
+		meta:       m,
+		executor:   exec,
+		pushEngine: push,
+	}
+}
+
+func (l *Loader) Start() error {
+	session := l.executor.CreateSession("sys")
+	defer func() {
+		if err := session.Close(); err != nil {
+			log.Printf("failed to close session: %v", err)
+		}
+	}()
+	pull, err := l.executor.ExecuteSQLStatement(session, "select * from tables")
+	if err != nil {
+		return err
+	}
+	rows, err := pull.GetRows(-1)
+	if err != nil {
+		return err
+	}
+	for i := 0; i < rows.RowCount(); i++ {
+		row := rows.GetRow(i)
+		kind := row.GetString(1)
+		switch kind {
+		case meta.TableKindSource:
+			info := meta.DecodeSourceInfoRow(&row)
+			if err := l.meta.RegisterSource(info, false); err != nil {
+				return err
+			}
+			if err := l.pushEngine.CreateSource(info); err != nil {
+				return err
+			}
+		case meta.TableKindMaterializedView:
+			// TODO: Load materialized view
+		default:
+			return fmt.Errorf("unknown table kind %s", kind)
+		}
+	}
+	return nil
+}

--- a/meta/schema/loader_test.go
+++ b/meta/schema/loader_test.go
@@ -1,0 +1,91 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/squareup/pranadb/cluster"
+	"github.com/squareup/pranadb/command"
+	"github.com/squareup/pranadb/meta"
+	"github.com/squareup/pranadb/pull"
+	"github.com/squareup/pranadb/push"
+	"github.com/squareup/pranadb/sharder"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoader(t *testing.T) {
+	clus := cluster.NewFakeCluster(1, 1)
+	metaController, executor := runServer(t, clus)
+	session := executor.CreateSession("map")
+	_, err := executor.ExecuteSQLStatement(session, `create source location(
+				id bigint,
+				x varchar,
+				y varchar,
+				primary key (id)
+			)`)
+	require.NoError(t, err)
+	session = executor.CreateSession("movies")
+	_, err = executor.ExecuteSQLStatement(session, `create source actor(
+				id bigint,
+				name varchar,
+				age int,
+				primary key (id)
+			)`)
+	require.NoError(t, err)
+	_, err = executor.ExecuteSQLStatement(session, `create source movies(
+				id bigint,
+				title varchar,
+				director varchar,
+				year int,
+				primary key (id)
+			)`)
+	require.NoError(t, err)
+
+	mapSchema, ok := metaController.GetSchema("map")
+	require.True(t, ok)
+	require.Len(t, mapSchema.Tables, 1)
+	moviesSchema, ok := metaController.GetSchema("movies")
+	require.True(t, ok)
+	require.Len(t, moviesSchema.Tables, 2)
+
+	// Restart the server
+	_ = clus.Stop()
+	metaController, executor = runServer(t, clus)
+	_, ok = metaController.GetSchema("test")
+	require.False(t, ok)
+
+	loader := NewLoader(metaController, executor, executor.GetPushEngine())
+	require.NoError(t, loader.Start())
+
+	actualSchema, ok := metaController.GetSchema("map")
+	require.True(t, ok)
+	require.Equal(t, mapSchema, actualSchema)
+	actualSchema, ok = metaController.GetSchema("movies")
+	require.True(t, ok)
+	require.Equal(t, moviesSchema, actualSchema)
+}
+
+func runServer(t *testing.T, clus cluster.Cluster) (*meta.Controller, *command.Executor) {
+	t.Helper()
+
+	metaController := meta.NewController(clus)
+	shardr := sharder.NewSharder(clus)
+	pushEngine := push.NewPushEngine(clus, shardr)
+	pullEngine := pull.NewPullEngine(clus, metaController)
+	ce := command.NewCommandExecutor(metaController, pushEngine, pullEngine, clus)
+	clus.RegisterNotificationListener(cluster.NotificationTypeDDLStatement, ce)
+	clus.RegisterNotificationListener(cluster.NotificationTypeCloseSession, pullEngine)
+	clus.SetRemoteQueryExecutionCallback(pullEngine)
+	clus.RegisterShardListenerFactory(pushEngine)
+	err := clus.Start()
+	require.NoError(t, err)
+	err = metaController.Start()
+	require.NoError(t, err)
+	err = pushEngine.Start()
+	require.NoError(t, err)
+	err = pullEngine.Start()
+	require.NoError(t, err)
+	err = shardr.Start()
+	require.NoError(t, err)
+
+	return metaController, ce
+}


### PR DESCRIPTION
This only implements source loading. Materialized views require a second
sequence ID for the aggregation table but the ID isn't stored anywhere
so idk where to load it from. https://github.com/squareup/pranadb/blob/386572750f586d7448944568fcdcf690a9b54420/push/exec_builder.go#L121