### PR TITLE
fix TestSqlClustered, reduce log spam

### DIFF
--- a/cluster/dragon/dragon.go
+++ b/cluster/dragon/dragon.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/lni/dragonboat/v3"
 	"github.com/lni/dragonboat/v3/config"
+	"github.com/lni/dragonboat/v3/logger"
 	"github.com/lni/dragonboat/v3/raftio"
 	"github.com/lni/dragonboat/v3/statemachine"
 	"github.com/pkg/errors"
@@ -76,6 +77,15 @@ type Dragon struct {
 	testDragon                   bool
 	shuttingDown                 bool
 	membershipListener           cluster.MembershipListener
+}
+
+func init() {
+	// This should be customizable, but these are good defaults
+	logger.GetLogger("dragonboat").SetLevel(logger.WARNING)
+	logger.GetLogger("raft").SetLevel(logger.ERROR)
+	logger.GetLogger("rsm").SetLevel(logger.ERROR)
+	logger.GetLogger("transport").SetLevel(logger.WARNING)
+	logger.GetLogger("grpc").SetLevel(logger.WARNING)
 }
 
 func (d *Dragon) RegisterMembershipListener(listener cluster.MembershipListener) {
@@ -468,7 +478,7 @@ func (d *Dragon) joinShardGroups() error {
 func (d *Dragon) joinShardGroup(shardID uint64, nodeIDs []int, ch chan error) {
 	rc := config.Config{
 		NodeID:             uint64(d.nodeID + 1),
-		ElectionRTT:        5,
+		ElectionRTT:        10,
 		HeartbeatRTT:       1,
 		CheckQuorum:        true,
 		SnapshotEntries:    10,
@@ -494,7 +504,7 @@ func (d *Dragon) joinShardGroup(shardID uint64, nodeIDs []int, ch chan error) {
 func (d *Dragon) joinSequenceGroup() error {
 	rc := config.Config{
 		NodeID:             uint64(d.nodeID + 1),
-		ElectionRTT:        5,
+		ElectionRTT:        10,
 		HeartbeatRTT:       1,
 		CheckQuorum:        true,
 		SnapshotEntries:    10,
@@ -516,7 +526,7 @@ func (d *Dragon) joinSequenceGroup() error {
 func (d *Dragon) joinNotificationGroup() error {
 	rc := config.Config{
 		NodeID:             uint64(d.nodeID + 1),
-		ElectionRTT:        5,
+		ElectionRTT:        10,
 		HeartbeatRTT:       1,
 		CheckQuorum:        false,
 		SnapshotEntries:    10,

--- a/cluster/fake_cluster.go
+++ b/cluster/fake_cluster.go
@@ -129,8 +129,6 @@ func (f *FakeCluster) Stop() error {
 	if !f.started {
 		return nil
 	}
-	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.remoteQueryExecutionCallback = nil
 	f.shardListenerFactory = nil
 	f.shardListeners = make(map[uint64]ShardListener)

--- a/sqltest/sql_test.go
+++ b/sqltest/sql_test.go
@@ -3,8 +3,6 @@ package sqltest
 import (
 	"bufio"
 	"fmt"
-	"github.com/squareup/pranadb/common/commontest"
-	"github.com/squareup/pranadb/table"
 	"io/ioutil"
 	"log"
 	"math/rand"
@@ -15,6 +13,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/squareup/pranadb/common/commontest"
+	"github.com/squareup/pranadb/table"
 
 	"github.com/squareup/pranadb/errors"
 	"github.com/squareup/pranadb/sess"
@@ -126,12 +127,19 @@ func (w *sqlTestsuite) setupPranaCluster(fakeCluster bool, numNodes int) {
 		}
 	}
 
+	wg := sync.WaitGroup{}
 	for _, prana := range w.pranaCluster {
-		err := prana.Start()
-		if err != nil {
-			log.Fatal(err)
-		}
+		wg.Add(1)
+		prana := prana
+		go func() {
+			err := prana.Start()
+			if err != nil {
+				log.Fatal(err)
+			}
+			wg.Done()
+		}()
 	}
+	wg.Wait()
 }
 
 func (w *sqlTestsuite) setup(fakeCluster bool, numNodes int) {


### PR DESCRIPTION
Noticed the test wasn't actually flaky, it was blocking on node 1 starting...