### PR TITLE
Synchronized access to schema

### DIFF
--- a/meta/schema/loader_test.go
+++ b/meta/schema/loader_test.go
@@ -73,7 +73,7 @@ func TestLoader(t *testing.T) {
 				}
 				schema, ok := metaController.GetSchema(ddl.schema)
 				require.True(t, ok)
-				require.Len(t, schema.Tables, numTables)
+				require.Equal(t, schema.LenTables(), numTables)
 				expectedSchemas[ddl.schema] = schema
 			}
 

--- a/parplan/infoschema.go
+++ b/parplan/infoschema.go
@@ -37,10 +37,7 @@ type iSSchemaInfo struct {
 
 func schemaToInfoSchema(schema *common.Schema) infoschema.InfoSchema {
 
-	tableInfos := make(map[string]*common.TableInfo)
-	for name, tbl := range schema.Tables {
-		tableInfos[name] = tbl.GetTableInfo()
-	}
+	tableInfos := schema.GetAllTableInfos()
 	schemaInfo := iSSchemaInfo{
 		SchemaName:  schema.Name,
 		TablesInfos: tableInfos,

--- a/pull/exec_builder.go
+++ b/pull/exec_builder.go
@@ -114,7 +114,7 @@ func (p *PullEngine) buildPullDAG(session *sess.Session, plan core.PhysicalPlan,
 			panic("table scans only used on remote queries")
 		}
 		tableName := op.Table.Name.L
-		tbl, ok := schema.Tables[tableName]
+		tbl, ok := schema.GetTable(tableName)
 		if !ok {
 			return nil, fmt.Errorf("unknown source or materialized view %s", tableName)
 		}

--- a/push/engine.go
+++ b/push/engine.go
@@ -366,7 +366,7 @@ func (p *PushEngine) disconnectMV(schema *common.Schema, node exec.PushExecutor,
 	switch op := node.(type) {
 	case *exec.TableScan:
 		tableName := op.TableName
-		tbl, ok := schema.Tables[tableName]
+		tbl, ok := schema.GetTable(tableName)
 		if !ok {
 			return fmt.Errorf("unknown source or materialized view %s", tableName)
 		}

--- a/push/exec_builder.go
+++ b/push/exec_builder.go
@@ -192,7 +192,7 @@ func (p *PushEngine) updateSchemas(executor exec.PushExecutor, schema *common.Sc
 	switch op := executor.(type) {
 	case *exec.TableScan:
 		tableName := op.TableName
-		tbl, ok := schema.Tables[tableName]
+		tbl, ok := schema.GetTable(tableName)
 		if !ok {
 			return fmt.Errorf("unknown source or materialized view %s", tableName)
 		}

--- a/sqltest/sql_test.go
+++ b/sqltest/sql_test.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"math/rand"
 	"os"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -304,7 +303,7 @@ func (st *sqlTest) runTestIteration(require *require.Assertions, commands []stri
 		ok, err := commontest.WaitUntilWithError(func() (bool, error) {
 			testSchema, ok := prana.GetMetaController().GetSchema(TestSchemaName)
 			require.True(ok)
-			if len(testSchema.Tables) != 0 || len(testSchema.Sinks) != 0 {
+			if testSchema.LenTables() != 0 {
 				return false, nil
 			}
 			err := prana.GetPushEngine().VerifyNoSourcesOrMVs()
@@ -515,7 +514,7 @@ func (st *sqlTest) waitForSchemaSame(require *require.Assertions) {
 				return false, nil
 			}
 			if schemaPrev != nil {
-				if !reflect.DeepEqual(schemaPrev, schemaNew) {
+				if !schemaPrev.Equal(schemaNew) {
 					return false, nil
 				}
 			}


### PR DESCRIPTION
Instances of schema are returned from the meta controller, and the internal state of the schema can then be mutated as tables are added or removed which can cause concurrent map read/write errors. This PR synchronises access to the internal state to prevent this.

Also in this PR an unnecessary sync in the shard state machine is removed.