### PR TITLE
Don't always cache remote sessions 

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -74,7 +74,7 @@ type sessCloser struct {
 	notifClient notifier.Client
 }
 
-func (s *sessCloser) CloseSession(sessionID string) error {
+func (s *sessCloser) CloseRemoteSessions(sessionID string) error {
 	shardIDs := s.clus.GetAllShardIDs()
 	for _, shardID := range shardIDs {
 		sessID := fmt.Sprintf("%s-%d", sessionID, shardID)


### PR DESCRIPTION
No need to cache remote sessions unless there are prepared statements or running queries. If there are no remote sessions then on session close, no need to broadcast session.close()