### PR TITLE
snapshots get written as sstables

### DIFF
--- a/cluster/dragon/dragon.go
+++ b/cluster/dragon/dragon.go
@@ -57,6 +57,7 @@ type Dragon struct {
 	nodeAddresses                []string
 	totShards                    int
 	dataDir                      string
+	ingestDir                    string
 	pebble                       *pebble.DB
 	nh                           *dragonboat.NodeHost
 	shardAllocs                  map[uint64][]int
@@ -181,6 +182,7 @@ func (d *Dragon) Start() error {
 
 	datadir := filepath.Join(d.dataDir, fmt.Sprintf("node-%d", d.nodeID))
 	pebbleDir := filepath.Join(datadir, "pebble")
+	d.ingestDir = filepath.Join(datadir, "ingest-snapshots")
 
 	// TODO used tuned config for Pebble - this can be copied from the Dragonboat Pebble config (see kv_pebble.go in Dragonboat)
 	pebbleOptions := &pebble.Options{}

--- a/cluster/dragon/integration/dragon_integration_test.go
+++ b/cluster/dragon/integration/dragon_integration_test.go
@@ -1,4 +1,4 @@
-package dragon
+package integration
 
 import (
 	"errors"
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	dragon "github.com/squareup/pranadb/cluster/dragon"
 	"github.com/stretchr/testify/require"
 
 	"github.com/squareup/pranadb/cluster"
@@ -205,15 +206,15 @@ func startDragonCluster(dataDir string) ([]cluster.Cluster, error) {
 	for i := 0; i < len(chans); i++ {
 		ch := make(chan error)
 		chans[i] = ch
-		dragon, err := NewDragon(i, 123, nodeAddresses, numShards, dataDir, 3, true)
+		clus, err := dragon.NewDragon(i, 123, nodeAddresses, numShards, dataDir, 3, true)
 		if err != nil {
 			return nil, err
 		}
-		clusterNodes[i] = dragon
-		dragon.RegisterShardListenerFactory(&cluster.DummyShardListenerFactory{})
-		dragon.SetRemoteQueryExecutionCallback(&cluster.DummyRemoteQueryExecutionCallback{})
+		clusterNodes[i] = clus
+		clus.RegisterShardListenerFactory(&cluster.DummyShardListenerFactory{})
+		clus.SetRemoteQueryExecutionCallback(&cluster.DummyRemoteQueryExecutionCallback{})
 
-		go startDragonNode(dragon, ch)
+		go startDragonNode(clus, ch)
 	}
 
 	for i := 0; i < len(chans); i++ {
@@ -230,8 +231,8 @@ func startDragonCluster(dataDir string) ([]cluster.Cluster, error) {
 	return clusterNodes, nil
 }
 
-func startDragonNode(dragon cluster.Cluster, ch chan error) {
-	err := dragon.Start()
+func startDragonNode(clus cluster.Cluster, ch chan error) {
+	err := clus.Start()
 	ch <- err
 }
 

--- a/cluster/dragon/sequence_odsm.go
+++ b/cluster/dragon/sequence_odsm.go
@@ -1,11 +1,12 @@
 package dragon
 
 import (
+	"io"
+
 	"github.com/cockroachdb/pebble"
 	"github.com/lni/dragonboat/v3/statemachine"
 	"github.com/squareup/pranadb/common"
 	"github.com/squareup/pranadb/table"
-	"io"
 )
 
 const (
@@ -90,7 +91,7 @@ func (s *sequenceODStateMachine) SaveSnapshot(i interface{}, writer io.Writer, i
 func (s *sequenceODStateMachine) RecoverFromSnapshot(reader io.Reader, i <-chan struct{}) error {
 	startPrefix := table.EncodeTableKeyPrefix(common.SequenceGeneratorTableID, s.shardID, 16)
 	endPrefix := table.EncodeTableKeyPrefix(common.SequenceGeneratorTableID+1, s.shardID, 16)
-	return restoreSnapshotDataFromReader(s.dragon.pebble, startPrefix, endPrefix, reader)
+	return restoreSnapshotDataFromReader(s.dragon.pebble, startPrefix, endPrefix, reader, s.dragon.ingestDir)
 }
 
 func (s *sequenceODStateMachine) Close() error {

--- a/cluster/dragon/shard_odsm.go
+++ b/cluster/dragon/shard_odsm.go
@@ -2,12 +2,13 @@ package dragon
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/cockroachdb/pebble"
 	"github.com/lni/dragonboat/v3/statemachine"
 	"github.com/squareup/pranadb/cluster"
 	"github.com/squareup/pranadb/common"
 	"github.com/squareup/pranadb/table"
-	"io"
 )
 
 const (
@@ -17,10 +18,6 @@ const (
 	shardStateMachineCommandDeleteRangePrefix      = 4
 
 	shardStateMachineResponseOK uint64 = 1
-
-	snapshotSaveBufferSize      = 8 * 1024
-	snapshotRecoverBufferSize   = 8 * 1024
-	maxSnapshotRecoverBatchSize = 10000
 )
 
 func newShardODStateMachine(d *Dragon, shardID uint64, nodeID int, nodeIDs []int) statemachine.IOnDiskStateMachine {
@@ -232,14 +229,14 @@ func (s *ShardOnDiskStateMachine) SaveSnapshot(i interface{}, writer io.Writer, 
 		panic("not a snapshot")
 	}
 	prefix := make([]byte, 0, 8)
-	prefix = common.AppendUint64ToBufferLE(prefix, s.shardID)
+	prefix = common.AppendUint64ToBufferBE(prefix, s.shardID)
 	return saveSnapshotDataToWriter(snapshot, prefix, writer, s.shardID)
 }
 
 func (s *ShardOnDiskStateMachine) RecoverFromSnapshot(reader io.Reader, i <-chan struct{}) error {
-	startPrefix := common.AppendUint64ToBufferLE(make([]byte, 0, 8), s.shardID)
-	endPrefix := common.AppendUint64ToBufferLE(make([]byte, 0, 8), s.shardID+1)
-	err := restoreSnapshotDataFromReader(s.dragon.pebble, startPrefix, endPrefix, reader)
+	startPrefix := common.AppendUint64ToBufferBE(make([]byte, 0, 8), s.shardID)
+	endPrefix := common.AppendUint64ToBufferBE(make([]byte, 0, 8), s.shardID+1)
+	err := restoreSnapshotDataFromReader(s.dragon.pebble, startPrefix, endPrefix, reader, s.dragon.ingestDir)
 	if err != nil {
 		return err
 	}

--- a/cluster/dragon/sm_utils.go
+++ b/cluster/dragon/sm_utils.go
@@ -1,25 +1,33 @@
 package dragon
 
 import (
-	"bufio"
+	"io"
+	"io/ioutil"
+	"math"
+	"os"
+
 	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/sstable"
 	"github.com/squareup/pranadb/common"
 	"github.com/squareup/pranadb/table"
-	"io"
-	"math"
 )
 
 var syncWriteOptions = &pebble.WriteOptions{Sync: true}
 var nosyncWriteOptions = &pebble.WriteOptions{Sync: false}
 
 func saveSnapshotDataToWriter(snapshot *pebble.Snapshot, prefix []byte, writer io.Writer, shardID uint64) error {
-	bufWriter := bufio.NewWriterSize(writer, snapshotSaveBufferSize)
+	var w writeCloseSyncer
+	w, ok := writer.(writeCloseSyncer)
+	if !ok {
+		w = &nopWriteCloseSyncer{writer}
+	}
+	tbl := sstable.NewWriter(w, sstable.WriterOptions{})
 	upper := common.IncrementBytesBigEndian(prefix)
 	iter := snapshot.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
 	for iter.First(); iter.Valid(); iter.Next() {
 		k := iter.Key()
 		v := iter.Value()
-		theShardID, _ := common.ReadUint64FromBufferLE(k, 8)
+		theShardID, _ := common.ReadUint64FromBufferBE(k, 0)
 		if theShardID != shardID {
 			// Sanity check
 			panic("wrong shard id!")
@@ -38,82 +46,50 @@ func saveSnapshotDataToWriter(snapshot *pebble.Snapshot, prefix []byte, writer i
 		if lv > math.MaxUint32 {
 			panic("value too long")
 		}
-		buff := make([]byte, 0, lk+lv+8)
-		buff = common.AppendUint32ToBufferLE(buff, uint32(len(k)))
-		buff = append(buff, k...)
-		buff = common.AppendUint32ToBufferLE(buff, uint32(len(v)))
-		buff = append(buff, v...)
-
-		if _, err := bufWriter.Write(buff); err != nil {
+		if err := tbl.Add(sstable.InternalKey{UserKey: k, Trailer: sstable.InternalKeyKindSet}, v); err != nil {
 			return err
 		}
 	}
-	// Write 0 to signify end of stream
-	buff := make([]byte, 0, 4)
-	buff = common.AppendUint32ToBufferLE(buff, 0)
-	if _, err := bufWriter.Write(buff); err != nil {
-		return err
-	}
-	if err := bufWriter.Flush(); err != nil {
+	if err := tbl.Close(); err != nil {
 		return err
 	}
 	return snapshot.Close()
 }
 
-func restoreSnapshotDataFromReader(peb *pebble.DB, startPrefix []byte, endPrefix []byte, reader io.Reader) error {
+func restoreSnapshotDataFromReader(peb *pebble.DB, startPrefix []byte, endPrefix []byte, reader io.Reader, ingestDir string) error {
+	f, err := ioutil.TempFile(ingestDir, "")
+	if err != nil {
+		return err
+	}
+	path := f.Name()
+	defer func() {
+		// Remove the file if we fail to ingest, to not leave around garbage data filling up the disk.
+		// After pebble ingests the file, it will be moved, so we expect this to fail in the good case.
+		// Thus ignore any errors.
+		_ = f.Close()
+		_ = os.Remove(path)
+	}()
 
-	wo := syncWriteOptions
+	if _, err := io.Copy(f, reader); err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
 
 	batch := peb.NewBatch()
-
 	// Delete the data for the state machine - we're going to replace it
 	if err := batch.DeleteRange(startPrefix, endPrefix, &pebble.WriteOptions{}); err != nil {
 		return err
 	}
-
-	bufReader := bufio.NewReaderSize(reader, snapshotRecoverBufferSize)
-
-	// Load kv pairs into the shard from the stream
-	batchSize := 0
-	lenBuf := make([]byte, 0, 4)
-	for {
-		lenBuf = lenBuf[0:4]
-		if _, err := io.ReadFull(bufReader, lenBuf); err != nil {
-			return err
-		}
-		lk, _ := common.ReadUint32FromBufferLE(lenBuf, 0)
-		if lk == 0 {
-			// Signifies end of stream
-			break
-		}
-		kb := make([]byte, 0, lk)
-		if _, err := io.ReadFull(bufReader, kb); err != nil {
-			return err
-		}
-
-		lenBuf = lenBuf[0:4]
-		if _, err := io.ReadFull(bufReader, lenBuf); err != nil {
-			return err
-		}
-		lv, _ := common.ReadUint32FromBufferLE(lenBuf, 0)
-		vb := make([]byte, 0, lv)
-		if _, err := io.ReadFull(bufReader, vb); err != nil {
-			return err
-		}
-
-		if err := batch.Set(kb, vb, nil); err != nil {
-			return err
-		}
-		batchSize++
-		if batchSize == maxSnapshotRecoverBatchSize {
-			if err := peb.Apply(batch, wo); err != nil {
-				return err
-			}
-			batch = peb.NewBatch()
-			batchSize = 0
-		}
+	if err := peb.Apply(batch, syncWriteOptions); err != nil {
+		return err
 	}
-	return peb.Apply(batch, wo)
+
+	return peb.Ingest([]string{path})
 }
 
 func syncPebble(peb *pebble.DB) error {
@@ -144,4 +120,19 @@ func writeLastIndexValue(batch *pebble.Batch, val uint64, shardID uint64) error 
 	vb := make([]byte, 0, 8)
 	vb = common.AppendUint64ToBufferLE(vb, val)
 	return batch.Set(key, vb, nil)
+}
+
+type writeCloseSyncer interface {
+	io.WriteCloser
+	Sync() error
+}
+
+type nopWriteCloseSyncer struct{ io.Writer }
+
+func (w *nopWriteCloseSyncer) Close() error {
+	return nil
+}
+
+func (w *nopWriteCloseSyncer) Sync() error {
+	return nil
 }

--- a/cluster/dragon/sm_utils_test.go
+++ b/cluster/dragon/sm_utils_test.go
@@ -1,0 +1,79 @@
+package dragon
+
+import (
+	"bytes"
+	"math/rand"
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/table"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveRestoreSnapshot(t *testing.T) {
+	srcDB, err := pebble.Open(t.TempDir(), &pebble.Options{})
+	require.NoError(t, err)
+	dstDB, err := pebble.Open(t.TempDir(), &pebble.Options{})
+	require.NoError(t, err)
+
+	shardIDs := []uint64{'\x2a', '\x2b', '\x2c'}
+	tableID := uint64(100)
+	shardIDToSnapshot := shardIDs[1]
+	value := make([]byte, 10)
+
+	// Fills each shard's table with n keys and random values
+	randFill := func(db *pebble.DB, n int) {
+		for _, shardID := range shardIDs {
+			key := table.EncodeTableKeyPrefix(tableID, shardID, 20)
+			key = append(key, []byte{0, 0, 0, 0}...)
+			for i := 0; i < n; i++ {
+				key = common.IncrementBytesBigEndian(key)
+				rand.Read(value)
+				require.NoError(t, db.Set(key, value, &pebble.WriteOptions{}))
+			}
+		}
+	}
+
+	randFill(srcDB, 100)
+	randFill(dstDB, 200)
+
+	buf := &bytes.Buffer{}
+	snapshotPrefix := table.EncodeTableKeyPrefix(tableID, shardIDs[1], 20)
+	require.NoError(t, saveSnapshotDataToWriter(srcDB.NewSnapshot(), snapshotPrefix, buf, shardIDToSnapshot))
+
+	startPrefix := common.AppendUint64ToBufferBE(make([]byte, 0, 8), shardIDToSnapshot)
+	endPrefix := common.AppendUint64ToBufferBE(make([]byte, 0, 8), shardIDToSnapshot+1)
+	require.NoError(t, restoreSnapshotDataFromReader(dstDB, startPrefix, endPrefix, buf, os.TempDir()))
+
+	startPrefix = table.EncodeTableKeyPrefix(tableID, shardIDToSnapshot, 20)
+	endPrefix = common.AppendUint64ToBufferBE(make([]byte, 0, 8), shardIDToSnapshot+1)
+	srcIter := srcDB.NewIter(&pebble.IterOptions{
+		LowerBound: startPrefix,
+		UpperBound: endPrefix,
+	})
+	dstIter := dstDB.NewIter(&pebble.IterOptions{
+		LowerBound: startPrefix,
+		UpperBound: endPrefix,
+	})
+
+	first := true
+	count := 0
+	for srcIter.First(); srcIter.Valid(); srcIter.Next() {
+		if first {
+			dstIter.First()
+			first = false
+		} else {
+			dstIter.Next()
+		}
+		require.True(t, dstIter.Valid())
+
+		require.Equal(t, srcIter.Key(), dstIter.Key())
+		require.Equal(t, srcIter.Value(), dstIter.Value())
+
+		count++
+	}
+	require.Equal(t, 100, count)
+	require.False(t, dstIter.Next())
+}


### PR DESCRIPTION
Snapshots now get written using pebble's SSTable format, allowing it to ingest tables directly by just doing a filesystem move. Applied a few endianness fixes as well.

Closes #65