### PR TITLE
Fix: don't insert empty key when syncing

### DIFF
--- a/cluster/dragon/sm_utils.go
+++ b/cluster/dragon/sm_utils.go
@@ -118,9 +118,8 @@ func restoreSnapshotDataFromReader(peb *pebble.DB, startPrefix []byte, endPrefix
 
 func syncPebble(peb *pebble.DB) error {
 	// To force an fsync we just write a kv into the dummy sys table with sync = true
-	prefix := make([]byte, 0, 8)
-	common.AppendUint64ToBufferLE(prefix, common.SyncTableID)
-	return peb.Set(prefix, []byte{}, syncWriteOptions)
+	key := common.AppendUint64ToBufferLE(make([]byte, 0, 8), common.SyncTableID)
+	return peb.Set(key, []byte{}, syncWriteOptions)
 }
 
 func loadLastProcessedRaftIndex(peb *pebble.DB, shardID uint64) (uint64, error) {


### PR DESCRIPTION
We were erroneously putting an empty key when syncing. Although Pebble supports null keys this was triggering a bug in Pebble that was not fixed in the Pebble release that we are using and which is being pulled in by Dragonboat.

Now we put a non null key. The pebble bug is still there but we don't trigger it any more.

More info here https://github.com/squareup/pranadb/issues/76