### PR TITLE
Execute notifications async to avoid starving heartbeat

### DIFF
--- a/notifier/client.go
+++ b/notifier/client.go
@@ -355,18 +355,16 @@ func (cc *clientConnection) heartbeatReceived() {
 	cc.hbReceived.Set(true)
 }
 
-func (cc *clientConnection) handleMessage(msgType messageType, msg []byte) error {
+func (cc *clientConnection) handleMessage(msgType messageType, msg []byte) {
 	if msgType == heartbeatMessageType {
 		cc.heartbeatReceived()
-		return nil
+		return
 	}
 	if msgType == notificationResponseMessageType {
 		resp := &NotificationResponse{}
-		if err := resp.deserialize(msg); err != nil {
-			return err
-		}
+		resp.deserialize(msg)
 		cc.client.responseReceived(cc, resp)
-		return nil
+		return
 	}
 	panic("unexpected message type")
 }

--- a/push/mover/mover.go
+++ b/push/mover/mover.go
@@ -4,7 +4,6 @@ import (
 	"github.com/squareup/pranadb/cluster"
 	"github.com/squareup/pranadb/common"
 	"github.com/squareup/pranadb/table"
-	"log"
 	"sync"
 )
 
@@ -186,7 +185,6 @@ func (m *Mover) HandleReceivedRows(receivingShardID uint64, rawRowHandler RawRow
 	if err != nil {
 		return err
 	}
-	log.Printf("Committed remote batch on shard %d", receivingShardID)
 	return nil
 }
 


### PR DESCRIPTION
Previously heartbeats and notifications were executed serially on the same connection. This meant that if a notification took a long time to process > heartbeat interval then the client would not receive the heartbeat response and think the server is unavailable.

This PR changes the behaviour so that notifications are now executed concurrently on different goroutines while heartbeat responses are returned immediately. The total number of concurrently executing msgs is limited by using a channel.