### PR TITLE
use segmentio kafka by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/pingcap/tidb v1.1.0-beta.0.20210602102026-ad7102cdeedf
 	github.com/pingcap/tipb v0.0.0-20210525032549-b80be13ddf6c
 	github.com/pkg/errors v0.9.1
+	github.com/segmentio/kafka-go v0.4.17
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tikv/pd v1.1.0-beta.0.20210323123936-c8fa72502f16 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,7 @@ github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -203,6 +204,7 @@ github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/flosch/pongo2 v0.0.0-20190707114632-bbf5a6c351f4/go.mod h1:T9YF2M40nIgbVgp3rreNmTged+9HrbNTIQf1PsaIiTA=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
+github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsouza/fake-gcs-server v1.17.0/go.mod h1:D1rTE4YCyHFNa99oyJJ5HyclvN/0uQR+pM/VdlL83bw=
@@ -315,6 +317,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -430,6 +434,7 @@ github.com/klauspost/compress v1.8.2/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0
 github.com/klauspost/compress v1.9.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.5/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.7/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
+github.com/klauspost/compress v1.9.8/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.10.5 h1:7q6vHIqubShURwQz8cQK6yIe/xC3IF0Vm7TGfqjewrc=
 github.com/klauspost/compress v1.10.5/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/cpuid v1.2.1 h1:vJi+O/nMdFt0vqm8NZBI6wzALWdA2X+egi0ogNyrC/w=
@@ -538,6 +543,8 @@ github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCr
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d h1:U+PMnTlV2tu7RuMK5etusZG3Cf+rpow5hqQByeCzJ2g=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d/go.mod h1:lXfE4PvvTW5xOjO6Mba8zDPyw8M93B6AQ7frTGnMlA8=
+github.com/pierrec/lz4 v2.6.0+incompatible h1:Ix9yFKn1nSPBLFl/yZknTp8TU5G4Ps0JDmguYK6iH1A=
+github.com/pierrec/lz4 v2.6.0+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pingcap/badger v1.5.1-0.20200908111422-2e78ee155d19 h1:IXpGy7y9HyoShAFmzW2OPF0xCA5EOoSTyZHwsgYk9Ro=
 github.com/pingcap/badger v1.5.1-0.20200908111422-2e78ee155d19/go.mod h1:LyrqUOHZrUDf9oGi1yoz1+qw9ckSIhQb5eMa1acOLNQ=
 github.com/pingcap/br v5.1.0-alpha.0.20210526054934-d5f5f9df24f5+incompatible h1:JXkYrdHpoW0Ht6fI+pl9SC7OcNpYvJg8hc/6i+V60Eo=
@@ -637,6 +644,8 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/segmentio/kafka-go v0.4.17 h1:IyqRstL9KUTDb3kyGPOOa5VffokKWSEzN6geJ92dSDY=
+github.com/segmentio/kafka-go v0.4.17/go.mod h1:19+Eg7KwrNKy/PFhiIthEPkO8k+ac7/ZYXwYM9Df10w=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
@@ -744,6 +753,8 @@ github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6Ac
 github.com/vmihailenco/msgpack/v4 v4.3.11/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/msgpack/v5 v5.0.0-beta.1/go.mod h1:xlngVLeyQ/Qi05oQxhQ+oTuqa03RjMwMfk/7/TCs+QI=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
+github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
@@ -806,6 +817,7 @@ golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190506204251-e1dfcc566284/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/kafka/cflt_client.go
+++ b/kafka/cflt_client.go
@@ -1,16 +1,19 @@
+// +build confluent
+
 package kafka
 
 import (
 	"fmt"
-	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"log"
 	"sync"
 	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
 // Kafka Message Provider implementation that uses the standard Confluent golang client
 
-func NewCfltMessageProviderFactory(topicName string, props map[string]string, groupID string) MessageProviderFactory {
+func NewMessageProviderFactory(topicName string, props map[string]string, groupID string) MessageProviderFactory {
 	return &CfltMessageProviderFactory{
 		topicName: topicName,
 		props:     props,
@@ -37,6 +40,8 @@ type KafkaMessageProvider struct {
 	topicName string
 	krpf      *CfltMessageProviderFactory
 }
+
+var _ MessageProvider = &KafkaMessageProvider{}
 
 func (k *KafkaMessageProvider) RebalanceOccurred(cons *kafka.Consumer, event kafka.Event) error {
 	log.Printf("rebalance event received in consumer %v %p", event, k)

--- a/kafka/fake_kafka.go
+++ b/kafka/fake_kafka.go
@@ -2,6 +2,13 @@ package kafka
 
 import (
 	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
 	"github.com/pkg/errors"
 
 	log "github.com/sirupsen/logrus"
@@ -9,12 +16,6 @@ import (
 	"github.com/squareup/pranadb/common"
 
 	"github.com/squareup/pranadb/sharder"
-	"reflect"
-	"strconv"
-	"strings"
-	"sync"
-	"sync/atomic"
-	"time"
 )
 
 const maxBufferedMessagesPerPartition = 10000

--- a/kafka/segment_client.go
+++ b/kafka/segment_client.go
@@ -1,0 +1,145 @@
+// +build !confluent
+
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+	"github.com/squareup/pranadb/perrors"
+)
+
+// Kafka Message Provider implementation that uses the SegmentIO golang client
+
+func NewMessageProviderFactory(topicName string, props map[string]string, groupID string) MessageProviderFactory {
+	return &SegmentMessageProviderFactory{
+		topicName: topicName,
+		props:     props,
+		groupID:   groupID,
+	}
+}
+
+type SegmentMessageProviderFactory struct {
+	topicName string
+	props     map[string]string
+	groupID   string
+}
+
+func (smpf *SegmentMessageProviderFactory) NewMessageProvider() (MessageProvider, error) {
+	mp := &SegmentKafkaMessageProvider{}
+	mp.krpf = smpf
+	mp.topicName = smpf.topicName
+	return mp, nil
+}
+
+type SegmentKafkaMessageProvider struct {
+	lock      sync.Mutex
+	reader    *kafka.Reader
+	topicName string
+	krpf      *SegmentMessageProviderFactory
+}
+
+var _ MessageProvider = &SegmentKafkaMessageProvider{}
+
+func (p *SegmentKafkaMessageProvider) GetMessage(pollTimeout time.Duration) (*Message, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if p.reader == nil {
+		return nil, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), pollTimeout)
+	defer cancel()
+
+	msg, err := p.reader.FetchMessage(ctx)
+	if err != nil {
+		if err == context.DeadlineExceeded {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	headers := make([]MessageHeader, len(msg.Headers))
+	for i, hdr := range msg.Headers {
+		headers[i] = MessageHeader{
+			Key:   hdr.Key,
+			Value: hdr.Value,
+		}
+	}
+	m := &Message{
+		PartInfo: PartInfo{
+			PartitionID: int32(msg.Partition),
+			Offset:      msg.Offset,
+		},
+		TimeStamp: msg.Time,
+		Key:       msg.Key,
+		Value:     msg.Value,
+		Headers:   headers,
+	}
+	//log.Infof("recv %d %d", msg.Partition, atomic.AddInt32(&count, 1))
+	return m, nil
+}
+
+func (p *SegmentKafkaMessageProvider) CommitOffsets(offsets map[int32]int64) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if p.reader == nil {
+		return nil
+	}
+	kmsgs := make([]kafka.Message, 0, len(offsets))
+	for partition, offset := range offsets {
+		kmsgs = append(kmsgs, kafka.Message{
+			Topic:     p.topicName,
+			Partition: int(partition),
+			// The offset passed to commit is 1 higher than the offset of the original message.
+			Offset: offset - 1,
+		})
+	}
+
+	return p.reader.CommitMessages(context.Background(), kmsgs...)
+}
+
+func (p *SegmentKafkaMessageProvider) Stop() error {
+	return nil
+}
+
+func (p *SegmentKafkaMessageProvider) Close() error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	err := p.reader.Close()
+	p.reader = nil
+	return err
+}
+
+func (p *SegmentKafkaMessageProvider) Start() error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	cfg := &kafka.ReaderConfig{
+		GroupID:     p.krpf.groupID,
+		Topic:       p.krpf.topicName,
+		StartOffset: kafka.FirstOffset,
+	}
+	for k, v := range p.krpf.props {
+		if err := setProperty(cfg, k, v); err != nil {
+			return err
+		}
+	}
+	reader := kafka.NewReader(*cfg)
+	p.reader = reader
+	return nil
+}
+
+func setProperty(cfg *kafka.ReaderConfig, k, v string) error {
+	switch k {
+	case "bootstrap.servers":
+		cfg.Brokers = strings.Split(v, ",")
+	default:
+		return perrors.NewInvalidConfigurationError(fmt.Sprintf("unsupported segmentio/kafka-go client option: %s", v))
+	}
+	return nil
+}

--- a/kafkatest/kafka_integration_test.go
+++ b/kafkatest/kafka_integration_test.go
@@ -2,6 +2,13 @@ package kafkatest
 
 import (
 	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/squareup/pranadb/client"
 	"github.com/squareup/pranadb/common/commontest"
 	"github.com/squareup/pranadb/conf"
@@ -9,12 +16,6 @@ import (
 	"github.com/squareup/pranadb/server"
 	"github.com/squareup/pranadb/table"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
-	"log"
-	"os"
-	"sync"
-	"testing"
-	"time"
 )
 
 const numPartitions = 25
@@ -224,7 +225,7 @@ func waitUntilRowsInTable(t *testing.T, tableName string, numRows int, cluster [
 		totRows, err = getAllRowsInTable(tabInfo.ID, cluster)
 		require.NoError(t, err)
 		return totRows == numRows, nil
-	}, 60*time.Second, 100*time.Millisecond)
+	}, 30*time.Second, 100*time.Millisecond)
 	require.NoError(t, err)
 	if !ok {
 		for _, prana := range cluster {

--- a/push/source/consumer.go
+++ b/push/source/consumer.go
@@ -1,11 +1,12 @@
 package source
 
 import (
+	"time"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/squareup/pranadb/common"
 	"github.com/squareup/pranadb/kafka"
 	"github.com/squareup/pranadb/push/sched"
-	"time"
 )
 
 type MessageConsumer struct {

--- a/push/source/source.go
+++ b/push/source/source.go
@@ -2,6 +2,10 @@ package source
 
 import (
 	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/squareup/pranadb/conf"
 	"github.com/squareup/pranadb/kafka"
@@ -10,11 +14,6 @@ import (
 	"github.com/squareup/pranadb/push/mover"
 	"github.com/squareup/pranadb/push/sched"
 	"github.com/squareup/pranadb/table"
-
-	"strconv"
-
-	"sync"
-	"time"
 
 	"github.com/squareup/pranadb/cluster"
 	"github.com/squareup/pranadb/common"
@@ -87,8 +86,8 @@ func NewSource(sourceInfo *common.SourceInfo, tableExec *exec.TableExecutor, sha
 			return nil, err
 		}
 	case conf.BrokerClientDefault:
-		log.Printf("Creating confluent message provider factory")
-		msgProvFact = kafka.NewCfltMessageProviderFactory(ti.TopicName, props, groupID)
+		log.Printf("Creating real message provider factory")
+		msgProvFact = kafka.NewMessageProviderFactory(ti.TopicName, props, groupID)
 	default:
 		return nil, perrors.NewPranaErrorf(perrors.UnsupportedBrokerClientType, "Unsupported broker client type %d", brokerConf.ClientType)
 	}
@@ -233,7 +232,7 @@ func (s *Source) consumerError(err error, clientError bool) {
 		return
 		//panic("Got consumer error but souce is not started")
 	}
-	log.Errorf("Failure in consumer %v source will be stopped", err)
+	log.Errorf("Failure in consumer, source will be stopped: %v. ", err)
 	if err2 := s.stop(); err2 != nil {
 		return
 	}


### PR DESCRIPTION
Prana now uses https://github.com/segmentio/kafka-go, a popular and mature native Go library for Kafka. This allows prana to build without needing to manually compile librdkafka and openssl. This makes it significantly easier to develop Prana on M1 macs and for getting it into docker.

Confluent's client is now behind a build tag. Run `go test -tags confluent ...` to use the confluent kafka client.

Closes https://github.com/squareup/pranadb/issues/129