### PR TITLE
Update Prana CLI to support uploading protobufs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -45,7 +45,7 @@ Wait for all the servers to report they are started.
 Now we're going to start a Prana CLI. Open another terminal and type:
 
 ```
-go run cmd/prana/main.go
+go run cmd/prana/main.go shell
 ```
 
 The CLI should start and give you a prompt like this:

--- a/cmd/prana/commands/shell.go
+++ b/cmd/prana/commands/shell.go
@@ -1,0 +1,83 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/chzyer/readline"
+	log "github.com/sirupsen/logrus"
+	"github.com/squareup/pranadb/client"
+)
+
+type ShellCommand struct {
+	VI bool `help:"Enable VI mode."`
+}
+
+func (c *ShellCommand) Run(cl *client.Client) error {
+	sessionID, err := cl.CreateSession()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := cl.CloseSession(sessionID); err != nil {
+			log.Errorf("failed to close session %v", err)
+		}
+	}()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	rl, err := readline.NewEx(&readline.Config{
+		HistoryFile:            filepath.Join(home, ".prana.history"),
+		DisableAutoSaveHistory: true,
+		VimMode:                c.VI,
+	})
+	if err != nil {
+		return err
+	}
+	for {
+		// Gather multi-line statement terminated by a ;
+		rl.SetPrompt("pranadb> ")
+		cmd := []string{}
+		for {
+			line, err := rl.Readline()
+			if err == io.EOF {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			cmd = append(cmd, line)
+			if strings.HasSuffix(line, ";") {
+				break
+			}
+			rl.SetPrompt("         ")
+		}
+		statement := strings.Join(cmd, " ")
+		_ = rl.SaveHistory(statement)
+
+		if err := c.sendStatement(sessionID, statement, cl); err != nil {
+			return err
+		}
+	}
+}
+
+func (c *ShellCommand) sendStatement(sessionID string, statement string, cli *client.Client) error {
+	ch, err := cli.ExecuteStatement(sessionID, statement)
+	if err != nil {
+		return err
+	}
+	for line := range ch {
+		fmt.Println(line)
+	}
+	return nil
+}

--- a/cmd/prana/commands/upload_proto.go
+++ b/cmd/prana/commands/upload_proto.go
@@ -1,0 +1,46 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/squareup/pranadb/client"
+	"github.com/squareup/pranadb/protos/squareup/cash/pranadb/v1/service"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+type UploadProtoCommand struct {
+	FilePath string `arg:"" type:"existingfile" help:"The protobuf file descriptor set to upload"`
+}
+
+func (cmd *UploadProtoCommand) Run(cl *client.Client) error {
+	data, err := os.ReadFile(cmd.FilePath)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	fd := &descriptorpb.FileDescriptorSet{}
+	if err := proto.Unmarshal(data, fd); err != nil {
+		return errors.WithStack(err)
+	}
+	fmt.Println("Registering the following protoufs:")
+	for _, f := range fd.File {
+		fmt.Printf("\t%s\n", f.GetName())
+	}
+	fmt.Println()
+	if err := cl.RegisterProtobufs(context.Background(), &service.RegisterProtobufsRequest{Descriptors: fd}); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func (cmd *UploadProtoCommand) Help() string {
+	return `
+Prana requires a file descriptor set containing the full transitive closure of
+imports for the protobuf. To create one, use protoc, e.g.
+
+	protoc --include_imports --descriptor_set_out=<path_to_descriptor_file> PROTO_FILES
+`
+}

--- a/protolib/registry.go
+++ b/protolib/registry.go
@@ -145,6 +145,12 @@ func (s *ProtoRegistry) FindFileByPath(path string) (protoreflect.FileDescriptor
 }
 
 func (s *ProtoRegistry) RegisterFiles(descriptors *descriptorpb.FileDescriptorSet) error {
+	// Ensure the descriptor set is valid and contains all transitive dependencies.
+	_, err := protodesc.NewFiles(descriptors)
+	if err != nil {
+		return err
+	}
+
 	wb := cluster.NewWriteBatch(cluster.SystemSchemaShardID, false)
 	for _, fd := range descriptors.File {
 		if err := table.Upsert(ProtobufTableInfo.TableInfo, encodeDescriptorToRow(fd), wb); err != nil {


### PR DESCRIPTION
The prana shell has been moved to a sub-command

```
❯ prana shell
pranadb>
```

Uploading protobufs uses the `upload-proto` command. There are some descriptors in prana you can test with, like

```
❯ prana upload-proto ./protos/descriptors/squareup/cash/pranadb/testproto/v1/testproto.bin
Registering the following protoufs:
	google/protobuf/timestamp.proto
	squareup/cash/pranadb/testproto/v1/imports.proto
	squareup/cash/pranadb/testproto/v1/testproto.proto
```