### PR TITLE
fix deadlock in stopping engine with schedulers processing remote rows

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -22,8 +22,8 @@ import (
 type Executor struct {
 	cluster           cluster.Cluster
 	metaController    *meta.Controller
-	pushEngine        *push.PushEngine
-	pullEngine        *pull.PullEngine
+	pushEngine        *push.Engine
+	pullEngine        *pull.Engine
 	notifClient       notifier.Client
 	sessionIDSequence int64
 	ddlRunner         *DDLCommandRunner
@@ -36,8 +36,8 @@ type sessCloser struct {
 
 func NewCommandExecutor(
 	metaController *meta.Controller,
-	pushEngine *push.PushEngine,
-	pullEngine *pull.PullEngine,
+	pushEngine *push.Engine,
+	pullEngine *pull.Engine,
 	cluster cluster.Cluster,
 	notifClient notifier.Client,
 ) *Executor {
@@ -166,11 +166,11 @@ func (s *sessCloser) CloseRemoteSessions(sessionID string) error {
 }
 
 // GetPushEngine is only used in testing
-func (e *Executor) GetPushEngine() *push.PushEngine {
+func (e *Executor) GetPushEngine() *push.Engine {
 	return e.pushEngine
 }
 
-func (e *Executor) GetPullEngine() *pull.PullEngine {
+func (e *Executor) GetPullEngine() *pull.Engine {
 	return e.pullEngine
 }
 

--- a/meta/schema/loader.go
+++ b/meta/schema/loader.go
@@ -14,11 +14,11 @@ import (
 // controller and the push engine.
 type Loader struct {
 	meta       *meta.Controller
-	pushEngine *push.PushEngine
+	pushEngine *push.Engine
 	queryExec  common.SimpleQueryExec
 }
 
-func NewLoader(m *meta.Controller, push *push.PushEngine, queryExec common.SimpleQueryExec) *Loader {
+func NewLoader(m *meta.Controller, push *push.Engine, queryExec common.SimpleQueryExec) *Loader {
 	return &Loader{
 		meta:       m,
 		pushEngine: push,

--- a/pull/exec_builder.go
+++ b/pull/exec_builder.go
@@ -12,7 +12,7 @@ import (
 	"github.com/squareup/pranadb/pull/exec"
 )
 
-func (p *PullEngine) buildPullQueryExecutionFromQuery(session *sess.Session, query string, prepare bool, remote bool) (queryDAG exec.PullExecutor, err error) {
+func (p *Engine) buildPullQueryExecutionFromQuery(session *sess.Session, query string, prepare bool, remote bool) (queryDAG exec.PullExecutor, err error) {
 	ast, err := session.PullPlanner().Parse(query)
 	if err != nil {
 		return nil, err
@@ -20,7 +20,7 @@ func (p *PullEngine) buildPullQueryExecutionFromQuery(session *sess.Session, que
 	return p.buildPullQueryExecutionFromAst(session, ast, prepare, remote)
 }
 
-func (p *PullEngine) buildPullQueryExecutionFromAst(session *sess.Session, ast parplan.AstHandle, prepare bool, remote bool) (queryDAG exec.PullExecutor, err error) {
+func (p *Engine) buildPullQueryExecutionFromAst(session *sess.Session, ast parplan.AstHandle, prepare bool, remote bool) (queryDAG exec.PullExecutor, err error) {
 
 	// Build the physical plan
 	physicalPlan, logicalPlan, err := session.PullPlanner().BuildPhysicalPlan(ast, prepare)
@@ -57,7 +57,7 @@ func (p *PullEngine) buildPullQueryExecutionFromAst(session *sess.Session, ast p
 
 // TODO: extract functions and break apart giant switch
 // nolint: gocyclo
-func (p *PullEngine) buildPullDAG(session *sess.Session, plan core.PhysicalPlan, schema *common.Schema, remote bool) (exec.PullExecutor, error) {
+func (p *Engine) buildPullDAG(session *sess.Session, plan core.PhysicalPlan, schema *common.Schema, remote bool) (exec.PullExecutor, error) {
 	cols := plan.Schema().Columns
 	colTypes := make([]common.ColumnType, 0, len(cols))
 	colNames := make([]string, 0, len(cols))
@@ -164,7 +164,7 @@ func (p *PullEngine) buildPullDAG(session *sess.Session, plan core.PhysicalPlan,
 	return executor, nil
 }
 
-func (p *PullEngine) byItemsToDescAndSortExpression(byItems []*util.ByItems) ([]bool, []*common.Expression) {
+func (p *Engine) byItemsToDescAndSortExpression(byItems []*util.ByItems) ([]bool, []*common.Expression) {
 	lbi := len(byItems)
 	desc := make([]bool, lbi)
 	sortByExprs := make([]*common.Expression, lbi)

--- a/push/mover_test.go
+++ b/push/mover_test.go
@@ -316,7 +316,7 @@ func TestDedupOfForwards(t *testing.T) {
 	require.Equal(t, 0, rowsHandled)
 }
 
-func testQueueForRemoteSend(t *testing.T, startSequence int, store cluster.Cluster, shard *sharder.Sharder, pe *PushEngine) {
+func testQueueForRemoteSend(t *testing.T, startSequence int, store cluster.Cluster, shard *sharder.Sharder, pe *Engine) {
 	t.Helper()
 
 	colTypes := []common.ColumnType{common.BigIntColumnType, common.VarcharColumnType}
@@ -353,7 +353,7 @@ func testQueueForRemoteSend(t *testing.T, startSequence int, store cluster.Clust
 	require.Equal(t, uint64(numRows+startSequence), lastSeq)
 }
 
-func startup(t *testing.T) (cluster.Cluster, *sharder.Sharder, *PushEngine) {
+func startup(t *testing.T) (cluster.Cluster, *sharder.Sharder, *Engine) {
 	t.Helper()
 	if testing.Short() {
 		t.Skip("-short: skipped")
@@ -417,7 +417,7 @@ func loadRowAndVerifySame(t *testing.T, keyBytes []byte, expectedRow *common.Row
 }
 
 // nolint: unparam
-func queueRows(t *testing.T, numRows int, colTypes []common.ColumnType, rf *common.RowsFactory, shard *sharder.Sharder, pe *PushEngine,
+func queueRows(t *testing.T, numRows int, colTypes []common.ColumnType, rf *common.RowsFactory, shard *sharder.Sharder, pe *Engine,
 	localShardID uint64, store cluster.Cluster, sendingShardID uint64) []rowInfo {
 	t.Helper()
 	rows := generateRows(t, numRows, colTypes, shard, rf, localShardID)

--- a/push/mv.go
+++ b/push/mv.go
@@ -11,7 +11,7 @@ import (
 )
 
 type MaterializedView struct {
-	pe             *PushEngine
+	pe             *Engine
 	schema         *common.Schema
 	Info           *common.MaterializedViewInfo
 	tableExecutor  *exec.TableExecutor
@@ -21,7 +21,7 @@ type MaterializedView struct {
 }
 
 // CreateMaterializedView creates the materialized view but does not register it in memory
-func CreateMaterializedView(pe *PushEngine, pl *parplan.Planner, schema *common.Schema, mvName string, query string,
+func CreateMaterializedView(pe *Engine, pl *parplan.Planner, schema *common.Schema, mvName string, query string,
 	tableID uint64, seqGenerator common.SeqGenerator) (*MaterializedView, error) {
 	mv := MaterializedView{
 		pe:      pe,

--- a/server/server.go
+++ b/server/server.go
@@ -99,8 +99,8 @@ type Server struct {
 	cluster         cluster.Cluster
 	shardr          *sharder.Sharder
 	metaController  *meta.Controller
-	pushEngine      *push.PushEngine
-	pullEngine      *pull.PullEngine
+	pushEngine      *push.Engine
+	pullEngine      *pull.Engine
 	commandExecutor *command.Executor
 	schemaLoader    *schema.Loader
 	notifServer     notifier.Server
@@ -181,11 +181,11 @@ func (s *Server) GetSharder() *sharder.Sharder {
 	return s.shardr
 }
 
-func (s *Server) GetPushEngine() *push.PushEngine {
+func (s *Server) GetPushEngine() *push.Engine {
 	return s.pushEngine
 }
 
-func (s *Server) GetPullEngine() *pull.PullEngine {
+func (s *Server) GetPullEngine() *pull.Engine {
 	return s.pullEngine
 }
 


### PR DESCRIPTION
Replaced push engine remote consumers with a sync.Map
Also renamed push/pull engine to just engine