### PR TITLE
Fixes deadlock in response channel error response

### DIFF
--- a/notifier/client.go
+++ b/notifier/client.go
@@ -77,7 +77,7 @@ func (c *client) makeUnavailableWithLock(serverAddress string) {
 // BroadcastSync broadcasts a notification to all nodes and waits until all nodes have responded before returning
 func (c *client) BroadcastSync(notif Notification) error {
 	nf := c.createNotifcationMessage(notif, true)
-	respChan := make(chan bool, 1)
+	respChan := make(chan bool, len(c.serverAddresses))
 	ri := &responseInfo{respChan: respChan, conns: make(map[*clientConnection]struct{})}
 	c.responseChannels.Store(nf.sequence, ri)
 	if err := c.broadcast(nf, ri); err != nil {


### PR DESCRIPTION
Fixes deadlock where the error response channel was of size 1 so if another error response came back while the client was being closed, it would block attempting to write to the error response channel which meant the message loop never exited and the client wouldn't close as close waits for message loop to exit.