### PR TITLE
Ergonomics for selector syntax

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -90,13 +90,13 @@ pranadb> create source payments(
              keyencoding = "stringbytes",
              valueencoding = "json",
              columnselectors = (
-                 k,
-                 v.customer_id,
-                 t,
-                 v.amount,
-                 v.payment_type,
-                 v.currency,
-                 h.fraud_score
+                 meta("key"),
+                 customer_id,
+                 meta("timestamp"),
+                 amount,
+                 payment_type,
+                 currency,
+                 meta("header").fraud_score
              )
          );
 0 rows returned

--- a/command/parser/ast.go
+++ b/command/parser/ast.go
@@ -100,13 +100,13 @@ type CreateSource struct {
 }
 
 type TopicInformation struct {
-	BrokerName     string                  `"BrokerName" "=" @String`
-	TopicName      string                  `|"TopicName" "=" @String`
-	HeaderEncoding string                  `|"HeaderEncoding" "=" @String`
-	KeyEncoding    string                  `|"KeyEncoding" "=" @String`
-	ValueEncoding  string                  `|"ValueEncoding" "=" @String`
-	ColSelectors   []*selector.SelectorAST `|"ColumnSelectors" "=" "(" (@@ ("," @@)*)? ")"`
-	Properties     []*TopicInfoProperty    `|"Properties" "=" "(" (@@ ("," @@)*)? ")"`
+	BrokerName     string                        `"BrokerName" "=" @String`
+	TopicName      string                        `|"TopicName" "=" @String`
+	HeaderEncoding string                        `|"HeaderEncoding" "=" @String`
+	KeyEncoding    string                        `|"KeyEncoding" "=" @String`
+	ValueEncoding  string                        `|"ValueEncoding" "=" @String`
+	ColSelectors   []*selector.ColumnSelectorAST `|"ColumnSelectors" "=" "(" (@@ ("," @@)*)? ")"`
+	Properties     []*TopicInfoProperty          `|"Properties" "=" "(" (@@ ("," @@)*)? ")"`
 }
 
 type ColSelector struct {

--- a/command/parser/ast_test.go
+++ b/command/parser/ast_test.go
@@ -51,10 +51,10 @@ func TestParse(t *testing.T) {
 			keyencoding = "json",
 			valueencoding = "json",
 			columnselectors = (
-				k.k0,
-				v.v1,
-				v.v2,
-				v[0][1].foo["test"]
+				meta("key").k0,
+				v1,
+				v2,
+				foo[0][1].bar["test"]
 			),
 			properties = (
 			"prop1" = "val1",
@@ -75,12 +75,12 @@ func TestParse(t *testing.T) {
 					{HeaderEncoding: "json"},
 					{KeyEncoding: "json"},
 					{ValueEncoding: "json"},
-					{ColSelectors: []*selector.SelectorAST{
-						{Field: "k", Next: &selector.SelectorAST{Field: "k0"}},
-						{Field: "v", Next: &selector.SelectorAST{Field: "v1"}},
-						{Field: "v", Next: &selector.SelectorAST{Field: "v2"}},
-						{Field: "v", Index: []*selector.Index{{Number: intRef(0)}, {Number: intRef(1)}},
-							Next: &selector.SelectorAST{Field: "foo", Index: []*selector.Index{{String: stringRef("test")}}},
+					{ColSelectors: []*selector.ColumnSelectorAST{
+						{MetaKey: stringRef("key"), Next: &selector.SelectorAST{Field: "k0"}},
+						{Field: stringRef("v1")},
+						{Field: stringRef("v2")},
+						{Field: stringRef("foo"), Index: []*selector.Index{{Number: intRef(0)}, {Number: intRef(1)}},
+							Next: &selector.SelectorAST{Field: "bar", Index: []*selector.Index{{String: stringRef("test")}}},
 						},
 					},
 					},

--- a/common/meta.go
+++ b/common/meta.go
@@ -266,7 +266,7 @@ type TopicInfo struct {
 	KeyEncoding    KafkaEncoding
 	ValueEncoding  KafkaEncoding
 	HeaderEncoding KafkaEncoding
-	ColSelectors   []selector.Selector
+	ColSelectors   []selector.ColumnSelector
 	Properties     map[string]string
 }
 

--- a/kafkatest/kafka_integration_test.go
+++ b/kafkatest/kafka_integration_test.go
@@ -88,13 +88,13 @@ create source payments(
     keyencoding = "stringbytes",
     valueencoding = "json",
     columnselectors = (
-        k,
-        v.customer_id,
-        t,
-        v.amount,
-        v.payment_type,
-        v.currency,
-        h.fraud_score
+        meta("key"),
+        customer_id,
+        meta("timestamp"),
+        amount,
+        payment_type,
+        currency,
+        meta("header").fraud_score
     ),
     properties = ()
 )

--- a/meta/schema/loader_test.go
+++ b/meta/schema/loader_test.go
@@ -40,9 +40,9 @@ func TestLoader(t *testing.T) {
 						keyencoding = "json",
 						valueencoding = "json",
 						columnselectors = (
-							k.k0,
-							v.v1,
-							v.v2
+							meta("key").k0,
+							v1,
+							v2
 						),
 						properties = (
 							"prop1" = "val1",
@@ -61,9 +61,9 @@ func TestLoader(t *testing.T) {
 						keyencoding = "json",
 						valueencoding = "json",
 						columnselectors = (
-							k.k0,
-							v.v1,
-							v.v2
+							meta("key").k0,
+							v1,
+							v2
 						),
 						properties = (
 							"prop1" = "val1",
@@ -79,10 +79,10 @@ func TestLoader(t *testing.T) {
 						keyencoding = "json",
 						valueencoding = "json",
 						columnselectors = (
-							k.k0,
-							v.v1,
-							v.v2,
-							v.v3
+							meta("key").k0,
+							v1,
+							v2,
+							v3
 						),
 						properties = (
 							"prop1" = "val1",
@@ -105,10 +105,10 @@ func TestLoader(t *testing.T) {
 						keyencoding = "json",
 						valueencoding = "json",
 						columnselectors = (
-							k.k0,
-							v.v1,
-							v.v2,
-							v.v3
+							meta("key").k0,
+							v1,
+							v2,
+							v3
 						),
 						properties = (
 							"prop1" = "val1",

--- a/sqltest/testdata/aggregation_count_test_out.txt
+++ b/sqltest/testdata/aggregation_count_test_out.txt
@@ -16,12 +16,12 @@ create source latest_sensor_readings(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5
     )
 );
 0 rows returned

--- a/sqltest/testdata/aggregation_count_test_script.txt
+++ b/sqltest/testdata/aggregation_count_test_script.txt
@@ -15,12 +15,12 @@ create source latest_sensor_readings(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5
     )
 );
 

--- a/sqltest/testdata/aggregation_max_test_out.txt
+++ b/sqltest/testdata/aggregation_max_test_out.txt
@@ -16,12 +16,12 @@ create source latest_sensor_readings(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5
     )
 );
 0 rows returned

--- a/sqltest/testdata/aggregation_max_test_script.txt
+++ b/sqltest/testdata/aggregation_max_test_script.txt
@@ -15,12 +15,12 @@ create source latest_sensor_readings(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5
     )
 );
 

--- a/sqltest/testdata/aggregation_min_test_out.txt
+++ b/sqltest/testdata/aggregation_min_test_out.txt
@@ -16,12 +16,12 @@ create source latest_sensor_readings(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5
     )
 );
 0 rows returned

--- a/sqltest/testdata/aggregation_min_test_script.txt
+++ b/sqltest/testdata/aggregation_min_test_script.txt
@@ -15,12 +15,12 @@ create source latest_sensor_readings(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5
     )
 );
 

--- a/sqltest/testdata/aggregation_sum_test_out.txt
+++ b/sqltest/testdata/aggregation_sum_test_out.txt
@@ -16,12 +16,12 @@ create source latest_sensor_readings(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5
     )
 );
 0 rows returned

--- a/sqltest/testdata/aggregation_sum_test_script.txt
+++ b/sqltest/testdata/aggregation_sum_test_script.txt
@@ -15,12 +15,12 @@ create source latest_sensor_readings(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5
     )
 );
 

--- a/sqltest/testdata/basic_mv_test_out.txt
+++ b/sqltest/testdata/basic_mv_test_out.txt
@@ -17,13 +17,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/basic_mv_test_script.txt
+++ b/sqltest/testdata/basic_mv_test_script.txt
@@ -16,13 +16,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/basic_source_test_out.txt
+++ b/sqltest/testdata/basic_source_test_out.txt
@@ -17,13 +17,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/basic_source_test_script.txt
+++ b/sqltest/testdata/basic_source_test_script.txt
@@ -16,13 +16,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/cascading_mvs_test_out.txt
+++ b/sqltest/testdata/cascading_mvs_test_out.txt
@@ -18,13 +18,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/cascading_mvs_test_script.txt
+++ b/sqltest/testdata/cascading_mvs_test_script.txt
@@ -17,13 +17,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/cluster_restart_test_out.txt
+++ b/sqltest/testdata/cluster_restart_test_out.txt
@@ -19,13 +19,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",
@@ -51,13 +51,13 @@ create source test_source_2(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/cluster_restart_test_script.txt
+++ b/sqltest/testdata/cluster_restart_test_script.txt
@@ -18,13 +18,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",
@@ -49,13 +49,13 @@ create source test_source_2(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/compound_pk_test_out.txt
+++ b/sqltest/testdata/compound_pk_test_out.txt
@@ -14,10 +14,10 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3
+        meta("key").k0,
+        v1,
+        v2,
+        v3
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/compound_pk_test_script.txt
+++ b/sqltest/testdata/compound_pk_test_script.txt
@@ -13,10 +13,10 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3
+        meta("key").k0,
+        v1,
+        v2,
+        v3
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/invalid_create_source_test_out.txt
+++ b/sqltest/testdata/invalid_create_source_test_out.txt
@@ -15,8 +15,8 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1
+        meta("key").k0,
+        v1
     )
 );
 0 rows returned
@@ -38,13 +38,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
+        meta("key").k0,
         v1,
     )
 );
 Failed to execute statement: PDB0002 - 13:11: unexpected token "," (expected ")")
 
--- TEST3 - missing prefix on column selector;
+-- TEST3 - invalid meta key on column selector;
 ------------------------------------------------------------;
 
 create source test_source_1(
@@ -58,11 +58,11 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
+        meta("notvalid").k0,
         v1
     )
 );
-Failed to execute statement: PDB0018 - invalid column selector "v1"
+Failed to execute statement: PDB0018 - invalid metadata key in column selector "meta(\"notvalid\").k0". Valid values are "header", "key", "timestamp".
 
 -- TEST4 - protobuf not registered;
 ------------------------------------------------------------;
@@ -78,7 +78,7 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "protobuf:foo.bar.MissingType",
     columnselectors = (
-        k.k0,
+        meta("key").k0,
         v1
     )
 );

--- a/sqltest/testdata/invalid_create_source_test_script.txt
+++ b/sqltest/testdata/invalid_create_source_test_script.txt
@@ -14,8 +14,8 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1
+        meta("key").k0,
+        v1
     )
 );
 
@@ -35,12 +35,12 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
+        meta("key").k0,
         v1,
     )
 );
 
--- TEST3 - missing prefix on column selector;
+-- TEST3 - invalid meta key on column selector;
 ------------------------------------------------------------;
 
 create source test_source_1(
@@ -54,7 +54,7 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
+        meta("notvalid").k0,
         v1
     )
 );
@@ -73,7 +73,7 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "protobuf:foo.bar.MissingType",
     columnselectors = (
-        k.k0,
+        meta("key").k0,
         v1
     )
 );

--- a/sqltest/testdata/message_encoding_test_out.txt
+++ b/sqltest/testdata/message_encoding_test_out.txt
@@ -23,13 +23,13 @@ create source test_source_1(
     keyencoding = "stringbytes",
     valueencoding = "json",
     columnselectors = (
-        v.v0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        k,
-        v.v6
+        v0,
+        v1,
+        v2,
+        v3,
+        v4,
+        meta("key"),
+        v6
     ),
     properties = (
         "prop1" = "val1",
@@ -79,13 +79,13 @@ create source test_source_1(
     keyencoding = "int64be",
     valueencoding = "json",
     columnselectors = (
-        k,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key"),
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",
@@ -135,13 +135,13 @@ create source test_source_1(
     keyencoding = "int32be",
     valueencoding = "json",
     columnselectors = (
-        v.v0,
-        v.v1,
-        k,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        v0,
+        v1,
+        meta("key"),
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",
@@ -191,13 +191,13 @@ create source test_source_1(
     keyencoding = "float64be",
     valueencoding = "json",
     columnselectors = (
-        v.v0,
-        v.v1,
-        v.v2,
-        k,
-        v.v4,
-        v.v5,
-        v.v6
+        v0,
+        v1,
+        v2,
+        meta("key"),
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",
@@ -247,13 +247,13 @@ create source test_source_1(
     keyencoding = "float32be",
     valueencoding = "json",
     columnselectors = (
-        v.v0,
-        v.v1,
-        v.v2,
-        k,
-        v.v4,
-        v.v5,
-        v.v6
+        v0,
+        v1,
+        v2,
+        meta("key"),
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",
@@ -303,13 +303,13 @@ create source test_source_1(
     keyencoding = "int16be",
     valueencoding = "json",
     columnselectors = (
-        v.v0,
-        v.v1,
-        k,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        v0,
+        v1,
+        meta("key"),
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",
@@ -358,13 +358,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",
@@ -413,13 +413,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.n0.k0,
-        v.n1.v1,
-        v.n2.v2,
-        v.n3.v3,
-        v.n4.v4,
-        v.n5.v5,
-        v.n6.v6
+        meta("key").n0.k0,
+        n1.v1,
+        n2.v2,
+        n3.v3,
+        n4.v4,
+        n5.v5,
+        n6.v6
     ),
     properties = (
         "prop1" = "val1",
@@ -468,13 +468,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        h.key.k0,
-        h.val.v1,
-        h.val.v2,
-        h.val.v3,
-        h.val.v4,
-        h.val.v5,
-        h.val.v6
+        meta("header").key.k0,
+        meta("header").val.v1,
+        meta("header").val.v2,
+        meta("header").val.v3,
+        meta("header").val.v4,
+        meta("header").val.v5,
+        meta("header").val.v6
     ),
     properties = (
         "prop1" = "val1",
@@ -523,13 +523,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        t
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        meta("timestamp")
     ),
     properties = (
         "prop1" = "val1",
@@ -581,16 +581,16 @@ create source test_source_1(
     keyencoding = "stringbytes",
     valueencoding = "protobuf:squareup.cash.pranadb.testproto.v1.TestTypes",
     columnselectors = (
-        v.double_field,
-        v.float_field,
-        v.int32_field,
-        v.int64_field,
-        v.uint32_field,
-        v.uint64_field,
-        v.bool_field,
-        k,
-        v.enum_field,
-        v.enum_field
+        double_field,
+        float_field,
+        int32_field,
+        int64_field,
+        uint32_field,
+        uint64_field,
+        bool_field,
+        meta("key"),
+        enum_field,
+        enum_field
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/message_encoding_test_script.txt
+++ b/sqltest/testdata/message_encoding_test_script.txt
@@ -22,13 +22,13 @@ create source test_source_1(
     keyencoding = "stringbytes",
     valueencoding = "json",
     columnselectors = (
-        v.v0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        k,
-        v.v6
+        v0,
+        v1,
+        v2,
+        v3,
+        v4,
+        meta("key"),
+        v6
     ),
     properties = (
         "prop1" = "val1",
@@ -64,13 +64,13 @@ create source test_source_1(
     keyencoding = "int64be",
     valueencoding = "json",
     columnselectors = (
-        k,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key"),
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",
@@ -106,13 +106,13 @@ create source test_source_1(
     keyencoding = "int32be",
     valueencoding = "json",
     columnselectors = (
-        v.v0,
-        v.v1,
-        k,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        v0,
+        v1,
+        meta("key"),
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",
@@ -148,13 +148,13 @@ create source test_source_1(
     keyencoding = "float64be",
     valueencoding = "json",
     columnselectors = (
-        v.v0,
-        v.v1,
-        v.v2,
-        k,
-        v.v4,
-        v.v5,
-        v.v6
+        v0,
+        v1,
+        v2,
+        meta("key"),
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",
@@ -190,13 +190,13 @@ create source test_source_1(
     keyencoding = "float32be",
     valueencoding = "json",
     columnselectors = (
-        v.v0,
-        v.v1,
-        v.v2,
-        k,
-        v.v4,
-        v.v5,
-        v.v6
+        v0,
+        v1,
+        v2,
+        meta("key"),
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",
@@ -232,13 +232,13 @@ create source test_source_1(
     keyencoding = "int16be",
     valueencoding = "json",
     columnselectors = (
-        v.v0,
-        v.v1,
-        k,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        v0,
+        v1,
+        meta("key"),
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",
@@ -273,13 +273,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",
@@ -314,13 +314,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.n0.k0,
-        v.n1.v1,
-        v.n2.v2,
-        v.n3.v3,
-        v.n4.v4,
-        v.n5.v5,
-        v.n6.v6
+        meta("key").n0.k0,
+        n1.v1,
+        n2.v2,
+        n3.v3,
+        n4.v4,
+        n5.v5,
+        n6.v6
     ),
     properties = (
         "prop1" = "val1",
@@ -355,13 +355,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        h.key.k0,
-        h.val.v1,
-        h.val.v2,
-        h.val.v3,
-        h.val.v4,
-        h.val.v5,
-        h.val.v6
+        meta("header").key.k0,
+        meta("header").val.v1,
+        meta("header").val.v2,
+        meta("header").val.v3,
+        meta("header").val.v4,
+        meta("header").val.v5,
+        meta("header").val.v6
     ),
     properties = (
         "prop1" = "val1",
@@ -396,13 +396,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        t
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        meta("timestamp")
     ),
     properties = (
         "prop1" = "val1",
@@ -440,16 +440,16 @@ create source test_source_1(
     keyencoding = "stringbytes",
     valueencoding = "protobuf:squareup.cash.pranadb.testproto.v1.TestTypes",
     columnselectors = (
-        v.double_field,
-        v.float_field,
-        v.int32_field,
-        v.int64_field,
-        v.uint32_field,
-        v.uint64_field,
-        v.bool_field,
-        k,
-        v.enum_field,
-        v.enum_field
+        double_field,
+        float_field,
+        int32_field,
+        int64_field,
+        uint32_field,
+        uint64_field,
+        bool_field,
+        meta("key"),
+        enum_field,
+        enum_field
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/move_session_test_out.txt
+++ b/sqltest/testdata/move_session_test_out.txt
@@ -17,13 +17,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/move_session_test_script.txt
+++ b/sqltest/testdata/move_session_test_script.txt
@@ -16,13 +16,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/multiple_mv_same_source_test_out.txt
+++ b/sqltest/testdata/multiple_mv_same_source_test_out.txt
@@ -17,13 +17,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 0 rows returned

--- a/sqltest/testdata/multiple_mv_same_source_test_script.txt
+++ b/sqltest/testdata/multiple_mv_same_source_test_script.txt
@@ -16,13 +16,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 

--- a/sqltest/testdata/multiple_mv_test_out.txt
+++ b/sqltest/testdata/multiple_mv_test_out.txt
@@ -17,13 +17,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 0 rows returned
@@ -66,13 +66,13 @@ create source test_source_2(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 0 rows returned
@@ -115,13 +115,13 @@ create source test_source_3(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 0 rows returned

--- a/sqltest/testdata/multiple_mv_test_script.txt
+++ b/sqltest/testdata/multiple_mv_test_script.txt
@@ -16,13 +16,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 
@@ -49,13 +49,13 @@ create source test_source_2(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 
@@ -82,13 +82,13 @@ create source test_source_3(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 

--- a/sqltest/testdata/multiple_source_test_out.txt
+++ b/sqltest/testdata/multiple_source_test_out.txt
@@ -17,13 +17,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 0 rows returned
@@ -64,13 +64,13 @@ create source test_source_2(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 0 rows returned
@@ -111,13 +111,13 @@ create source test_source_3(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 0 rows returned
@@ -233,13 +233,13 @@ create source test_source_3(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 Failed to execute statement: PDB0008 - Source already exists: test.test_source_3
@@ -276,13 +276,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 0 rows returned

--- a/sqltest/testdata/multiple_source_test_script.txt
+++ b/sqltest/testdata/multiple_source_test_script.txt
@@ -16,13 +16,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 
@@ -48,13 +48,13 @@ create source test_source_2(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 
@@ -80,13 +80,13 @@ create source test_source_3(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 
@@ -121,13 +121,13 @@ create source test_source_3(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 
@@ -157,13 +157,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 

--- a/sqltest/testdata/mv_fill_dynamic2_test_out.txt
+++ b/sqltest/testdata/mv_fill_dynamic2_test_out.txt
@@ -19,13 +19,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/mv_fill_dynamic2_test_script.txt
+++ b/sqltest/testdata/mv_fill_dynamic2_test_script.txt
@@ -18,13 +18,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/mv_fill_dynamic_test_out.txt
+++ b/sqltest/testdata/mv_fill_dynamic_test_out.txt
@@ -18,13 +18,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/mv_fill_dynamic_test_script.txt
+++ b/sqltest/testdata/mv_fill_dynamic_test_script.txt
@@ -17,13 +17,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/mv_fill_test_out.txt
+++ b/sqltest/testdata/mv_fill_test_out.txt
@@ -17,13 +17,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/mv_fill_test_script.txt
+++ b/sqltest/testdata/mv_fill_test_script.txt
@@ -16,13 +16,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/nulls_test_out.txt
+++ b/sqltest/testdata/nulls_test_out.txt
@@ -17,13 +17,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/nulls_test_script.txt
+++ b/sqltest/testdata/nulls_test_script.txt
@@ -16,13 +16,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/point_get_test_out.txt
+++ b/sqltest/testdata/point_get_test_out.txt
@@ -18,11 +18,11 @@ create source raw_ledger_events(
 	keyencoding = "stringbytes",
 	valueencoding = "json",
 	columnselectors = (
-		v.v0,
-        v.v1,
-		v.v2,
-		v.v3,
-		v.v4
+		v0,
+        v1,
+		v2,
+		v3,
+		v4
 	)
 );
 0 rows returned
@@ -64,11 +64,11 @@ create source raw_ledger_events(
 	keyencoding = "stringbytes",
 	valueencoding = "json",
 	columnselectors = (
-		v.v0,
-        v.v1,
-		v.v2,
-		v.v3,
-		v.v4
+		v0,
+        v1,
+		v2,
+		v3,
+		v4
 	)
 );
 0 rows returned
@@ -110,11 +110,11 @@ create source raw_ledger_events(
 	keyencoding = "stringbytes",
 	valueencoding = "json",
 	columnselectors = (
-		v.v0,
-        v.v1,
-		v.v2,
-		v.v3,
-		v.v4
+		v0,
+        v1,
+		v2,
+		v3,
+		v4
 	)
 );
 0 rows returned
@@ -156,11 +156,11 @@ create source raw_ledger_events(
 	keyencoding = "stringbytes",
 	valueencoding = "json",
 	columnselectors = (
-		v.v0,
-        v.v1,
-		v.v2,
-		v.v3,
-		v.v4
+		v0,
+        v1,
+		v2,
+		v3,
+		v4
 	)
 );
 0 rows returned
@@ -202,11 +202,11 @@ create source raw_ledger_events(
 	keyencoding = "stringbytes",
 	valueencoding = "json",
 	columnselectors = (
-		v.v0,
-        v.v1,
-		v.v2,
-		v.v3,
-		v.v4
+		v0,
+        v1,
+		v2,
+		v3,
+		v4
 	)
 );
 0 rows returned
@@ -248,11 +248,11 @@ create source raw_ledger_events(
 	keyencoding = "stringbytes",
 	valueencoding = "json",
 	columnselectors = (
-		v.v0,
-        v.v1,
-		v.v2,
-		v.v3,
-		v.v4
+		v0,
+        v1,
+		v2,
+		v3,
+		v4
 	)
 );
 0 rows returned

--- a/sqltest/testdata/point_get_test_script.txt
+++ b/sqltest/testdata/point_get_test_script.txt
@@ -17,11 +17,11 @@ create source raw_ledger_events(
 	keyencoding = "stringbytes",
 	valueencoding = "json",
 	columnselectors = (
-		v.v0,
-        v.v1,
-		v.v2,
-		v.v3,
-		v.v4
+		v0,
+        v1,
+		v2,
+		v3,
+		v4
 	)
 );
 --load data dataset_1;
@@ -50,11 +50,11 @@ create source raw_ledger_events(
 	keyencoding = "stringbytes",
 	valueencoding = "json",
 	columnselectors = (
-		v.v0,
-        v.v1,
-		v.v2,
-		v.v3,
-		v.v4
+		v0,
+        v1,
+		v2,
+		v3,
+		v4
 	)
 );
 --load data dataset_2;
@@ -83,11 +83,11 @@ create source raw_ledger_events(
 	keyencoding = "stringbytes",
 	valueencoding = "json",
 	columnselectors = (
-		v.v0,
-        v.v1,
-		v.v2,
-		v.v3,
-		v.v4
+		v0,
+        v1,
+		v2,
+		v3,
+		v4
 	)
 );
 --load data dataset_2;
@@ -116,11 +116,11 @@ create source raw_ledger_events(
 	keyencoding = "stringbytes",
 	valueencoding = "json",
 	columnselectors = (
-		v.v0,
-        v.v1,
-		v.v2,
-		v.v3,
-		v.v4
+		v0,
+        v1,
+		v2,
+		v3,
+		v4
 	)
 );
 --load data dataset_2;
@@ -149,11 +149,11 @@ create source raw_ledger_events(
 	keyencoding = "stringbytes",
 	valueencoding = "json",
 	columnselectors = (
-		v.v0,
-        v.v1,
-		v.v2,
-		v.v3,
-		v.v4
+		v0,
+        v1,
+		v2,
+		v3,
+		v4
 	)
 );
 --load data dataset_3;
@@ -182,11 +182,11 @@ create source raw_ledger_events(
 	keyencoding = "stringbytes",
 	valueencoding = "json",
 	columnselectors = (
-		v.v0,
-        v.v1,
-		v.v2,
-		v.v3,
-		v.v4
+		v0,
+        v1,
+		v2,
+		v3,
+		v4
 	)
 );
 --load data dataset_4;

--- a/sqltest/testdata/prepared_statements_test_out.txt
+++ b/sqltest/testdata/prepared_statements_test_out.txt
@@ -18,12 +18,12 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/prepared_statements_test_script.txt
+++ b/sqltest/testdata/prepared_statements_test_script.txt
@@ -17,12 +17,12 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/proto_register_test_out.txt
+++ b/sqltest/testdata/proto_register_test_out.txt
@@ -21,8 +21,8 @@ create source test_source_1(
     keyencoding = "stringbytes",
     valueencoding = "protobuf:squareup.cash.pranadb.testproto.v1.Simple",
     columnselectors = (
-        v.key,
-        v.val1
+        key,
+        val1
     )
 );
 0 rows returned
@@ -70,9 +70,9 @@ create source test_source_1(
     keyencoding = "stringbytes",
     valueencoding = "protobuf:squareup.cash.pranadb.testproto.v1.Simple",
     columnselectors = (
-        v.key,
-        v.val1,
-        v.val2
+        key,
+        val1,
+        val2
     )
 );
 0 rows returned
@@ -120,9 +120,9 @@ create source test_source_1(
     keyencoding = "stringbytes",
     valueencoding = "protobuf:squareup.cash.pranadb.testproto.v1.Simple",
     columnselectors = (
-        v.key,
-        v.val1,
-        v.val2
+        key,
+        val1,
+        val2
     )
 );
 0 rows returned

--- a/sqltest/testdata/proto_register_test_script.txt
+++ b/sqltest/testdata/proto_register_test_script.txt
@@ -20,8 +20,8 @@ create source test_source_1(
     keyencoding = "stringbytes",
     valueencoding = "protobuf:squareup.cash.pranadb.testproto.v1.Simple",
     columnselectors = (
-        v.key,
-        v.val1
+        key,
+        val1
     )
 );
 
@@ -54,9 +54,9 @@ create source test_source_1(
     keyencoding = "stringbytes",
     valueencoding = "protobuf:squareup.cash.pranadb.testproto.v1.Simple",
     columnselectors = (
-        v.key,
-        v.val1,
-        v.val2
+        key,
+        val1,
+        val2
     )
 );
 
@@ -89,9 +89,9 @@ create source test_source_1(
     keyencoding = "stringbytes",
     valueencoding = "protobuf:squareup.cash.pranadb.testproto.v1.Simple",
     columnselectors = (
-        v.key,
-        v.val1,
-        v.val2
+        key,
+        val1,
+        val2
     )
 );
 

--- a/sqltest/testdata/pull_project_test_out.txt
+++ b/sqltest/testdata/pull_project_test_out.txt
@@ -17,13 +17,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 0 rows returned

--- a/sqltest/testdata/pull_project_test_script.txt
+++ b/sqltest/testdata/pull_project_test_script.txt
@@ -16,13 +16,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 

--- a/sqltest/testdata/pull_select_test_out.txt
+++ b/sqltest/testdata/pull_select_test_out.txt
@@ -17,13 +17,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 0 rows returned

--- a/sqltest/testdata/pull_select_test_script.txt
+++ b/sqltest/testdata/pull_select_test_script.txt
@@ -16,13 +16,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 

--- a/sqltest/testdata/push_project_test_out.txt
+++ b/sqltest/testdata/push_project_test_out.txt
@@ -17,13 +17,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 0 rows returned

--- a/sqltest/testdata/push_project_test_script.txt
+++ b/sqltest/testdata/push_project_test_script.txt
@@ -16,13 +16,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 

--- a/sqltest/testdata/push_select_test_out.txt
+++ b/sqltest/testdata/push_select_test_out.txt
@@ -17,13 +17,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 0 rows returned

--- a/sqltest/testdata/push_select_test_script.txt
+++ b/sqltest/testdata/push_select_test_script.txt
@@ -16,13 +16,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 

--- a/sqltest/testdata/redelivery_kafka_failure_test_out.txt
+++ b/sqltest/testdata/redelivery_kafka_failure_test_out.txt
@@ -17,13 +17,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/redelivery_kafka_failure_test_script.txt
+++ b/sqltest/testdata/redelivery_kafka_failure_test_script.txt
@@ -16,13 +16,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/redelivery_prana_restart_test_out.txt
+++ b/sqltest/testdata/redelivery_prana_restart_test_out.txt
@@ -17,13 +17,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/redelivery_prana_restart_test_script.txt
+++ b/sqltest/testdata/redelivery_prana_restart_test_script.txt
@@ -16,13 +16,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/source_pk_test_out.txt
+++ b/sqltest/testdata/source_pk_test_out.txt
@@ -17,13 +17,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",
@@ -116,13 +116,13 @@ create source test_source_2(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/source_pk_test_script.txt
+++ b/sqltest/testdata/source_pk_test_script.txt
@@ -16,13 +16,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",
@@ -61,13 +61,13 @@ create source test_source_2(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     ),
     properties = (
         "prop1" = "val1",

--- a/sqltest/testdata/union_all_test_out.txt
+++ b/sqltest/testdata/union_all_test_out.txt
@@ -18,13 +18,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 0 rows returned
@@ -44,13 +44,13 @@ create source test_source_2(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 0 rows returned

--- a/sqltest/testdata/union_all_test_script.txt
+++ b/sqltest/testdata/union_all_test_script.txt
@@ -17,13 +17,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 create source test_source_2(
@@ -42,13 +42,13 @@ create source test_source_2(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 

--- a/sqltest/testdata/use_test_out.txt
+++ b/sqltest/testdata/use_test_out.txt
@@ -23,13 +23,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 0 rows returned
@@ -82,13 +82,13 @@ create source test_source_2(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 0 rows returned
@@ -144,13 +144,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 0 rows returned
@@ -204,13 +204,13 @@ create source test_source_3(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 0 rows returned

--- a/sqltest/testdata/use_test_script.txt
+++ b/sqltest/testdata/use_test_script.txt
@@ -22,13 +22,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 -- this mv name is also used in schema test2;
@@ -55,13 +55,13 @@ create source test_source_2(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 -- this mv name is only used in schema test1;
@@ -90,13 +90,13 @@ create source test_source_1(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 -- mv with same name as in test1;
@@ -124,13 +124,13 @@ create source test_source_3(
     keyencoding = "json",
     valueencoding = "json",
     columnselectors = (
-        k.k0,
-        v.v1,
-        v.v2,
-        v.v3,
-        v.v4,
-        v.v5,
-        v.v6
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
     )
 );
 create materialized view test_mv_3 as select * from test_source_3;


### PR DESCRIPTION
The message body's fields are now at the top level, no longer requiring the `v.` prefix. Headers, key, and timestamp are now exposed using the `meta()` function, as described in #243