### PR TITLE
pull in gap's error package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,6 +71,9 @@ linters-settings:
     list-type: blacklist
     include-go-root: true
     packages-with-error-message:
+      - errors: "use pranadb/errors"
+      - github.com/pkg/errors: "use pranadb/errors"
+      - github.com/pingcap/errors: "use pranadb/errors"
       - github.com/gogo/protobuf: "use github.com/golang/protobuf"
   exhaustive:
     default-signifies-exhaustive: true

--- a/aggfuncs/aggfuncs.go
+++ b/aggfuncs/aggfuncs.go
@@ -2,7 +2,7 @@ package aggfuncs
 
 import (
 	"github.com/squareup/pranadb/common"
-	"github.com/squareup/pranadb/perrors"
+	"github.com/squareup/pranadb/errors"
 )
 
 type AggregateFunction interface {
@@ -65,7 +65,7 @@ func NewAggregateFunction(argExpression *common.Expression, funcType AggFunction
 	case FirstRowAggregateFunctionType:
 		return &FirstRowAggregateFunction{aggregateFunctionBase: base}, nil
 	default:
-		return nil, perrors.Errorf("unexpected aggregate function type %d", funcType)
+		return nil, errors.Errorf("unexpected aggregate function type %d", funcType)
 	}
 }
 

--- a/aggfuncs/aggstate.go
+++ b/aggfuncs/aggstate.go
@@ -1,8 +1,9 @@
 package aggfuncs
 
 import (
-	"github.com/squareup/pranadb/common"
 	"unsafe"
+
+	"github.com/squareup/pranadb/common"
 )
 
 type AggState struct {

--- a/client/cli_test.go
+++ b/client/cli_test.go
@@ -2,12 +2,13 @@ package client
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/squareup/pranadb/common/commontest"
 	"github.com/squareup/pranadb/conf"
 	"github.com/squareup/pranadb/server"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 func TestSessionTimeout(t *testing.T) {

--- a/client/client.go
+++ b/client/client.go
@@ -2,14 +2,14 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"github.com/squareup/pranadb/perrors"
 	"io"
 	"math"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/squareup/pranadb/errors"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/squareup/pranadb/common"
@@ -86,7 +86,7 @@ func (c *Client) CreateSession() (string, error) {
 		return "", errors.New("not started")
 	}
 	if c.currentStatement != "" {
-		return "", perrors.Errorf("statement currently executing: %s", c.currentStatement)
+		return "", errors.Errorf("statement currently executing: %s", c.currentStatement)
 	}
 	resp, err := c.client.CreateSession(context.Background(), &emptypb.Empty{})
 	if err != nil {
@@ -104,7 +104,7 @@ func (c *Client) CloseSession(sessionID string) error {
 		return errors.New("not started")
 	}
 	if c.currentStatement != "" {
-		return perrors.Errorf("statement currently executing: %s", c.currentStatement)
+		return errors.Errorf("statement currently executing: %s", c.currentStatement)
 	}
 	_, err := c.client.CloseSession(context.Background(), &service.CloseSessionRequest{SessionId: sessionID})
 	delete(c.sessionIDs, sessionID)
@@ -120,7 +120,7 @@ func (c *Client) ExecuteStatement(sessionID string, statement string) (chan stri
 		return nil, errors.New("not started")
 	}
 	if c.currentStatement != "" {
-		return nil, perrors.Errorf("statement currently executing: %s", c.currentStatement)
+		return nil, errors.Errorf("statement currently executing: %s", c.currentStatement)
 	}
 	ch := make(chan string, maxBufferedLines)
 	c.currentStatement = statement
@@ -273,7 +273,7 @@ func stripgRPCPrefix(err error) error {
 		msg := err.Error()[ind:]
 		//Error string needs to be capitalized as this is what is displayed to the user in the CLI
 		//nolint:stylecheck
-		return perrors.Errorf("Failed to execute statement: %s", msg)
+		return errors.Errorf("Failed to execute statement: %s", msg)
 	}
 	return err
 }

--- a/cluster/dragon/integration/dragon_integration_test.go
+++ b/cluster/dragon/integration/dragon_integration_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -9,6 +8,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/squareup/pranadb/errors"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/squareup/pranadb/conf"

--- a/cluster/dragon/locks_odsm.go
+++ b/cluster/dragon/locks_odsm.go
@@ -1,12 +1,13 @@
 package dragon
 
 import (
-	log "github.com/sirupsen/logrus"
-	"github.com/squareup/pranadb/perrors"
 	"io"
 	"math"
 	"strings"
 	"sync"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/squareup/pranadb/errors"
 
 	"github.com/cockroachdb/pebble"
 	"github.com/lni/dragonboat/v3/statemachine"
@@ -100,7 +101,7 @@ outer:
 			}
 			s.setResult(true, entries, i)
 		} else {
-			return nil, perrors.Errorf("unknown lock command %s", command)
+			return nil, errors.Errorf("unknown lock command %s", command)
 		}
 	}
 	if err := writeLastIndexValue(batch, entries[len(entries)-1].Index, locksClusterID); err != nil {

--- a/cluster/dragon/sequence_odsm.go
+++ b/cluster/dragon/sequence_odsm.go
@@ -1,12 +1,13 @@
 package dragon
 
 import (
+	"io"
+
 	"github.com/cockroachdb/pebble"
 	"github.com/lni/dragonboat/v3/statemachine"
 	log "github.com/sirupsen/logrus"
 	"github.com/squareup/pranadb/common"
 	"github.com/squareup/pranadb/table"
-	"io"
 )
 
 const (

--- a/cluster/dragon/shard_odsm.go
+++ b/cluster/dragon/shard_odsm.go
@@ -2,13 +2,14 @@ package dragon
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/cockroachdb/pebble"
 	"github.com/lni/dragonboat/v3/statemachine"
 	log "github.com/sirupsen/logrus"
 	"github.com/squareup/pranadb/cluster"
 	"github.com/squareup/pranadb/common"
 	"github.com/squareup/pranadb/table"
-	"io"
 )
 
 const (

--- a/cluster/dragon/sm_utils.go
+++ b/cluster/dragon/sm_utils.go
@@ -1,12 +1,13 @@
 package dragon
 
 import (
-	log "github.com/sirupsen/logrus"
-	"github.com/squareup/pranadb/perrors"
 	"io"
 	"io/ioutil"
 	"math"
 	"os"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/squareup/pranadb/errors"
 
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/sstable"
@@ -32,7 +33,7 @@ func saveSnapshotDataToWriter(snapshot *pebble.Snapshot, prefix []byte, writer i
 		theShardID, _ := common.ReadUint64FromBufferBE(k, 0)
 		if theShardID != shardID {
 			// Sanity check
-			return perrors.Errorf("wrong shard id is %d was expecting %d key is %v upper bound is %v", theShardID, shardID, k, upper)
+			return errors.Errorf("wrong shard id is %d was expecting %d key is %v upper bound is %v", theShardID, shardID, k, upper)
 		}
 		lk := len(k)
 		lv := len(v)

--- a/cluster/fake_cluster.go
+++ b/cluster/fake_cluster.go
@@ -2,10 +2,11 @@ package cluster
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
+
+	"github.com/squareup/pranadb/errors"
 
 	"github.com/google/btree"
 

--- a/cluster/test_utils.go
+++ b/cluster/test_utils.go
@@ -1,9 +1,10 @@
 package cluster
 
 import (
+	"sync"
+
 	"github.com/squareup/pranadb/common"
 	"github.com/squareup/pranadb/notifier"
-	"sync"
 )
 
 type TestNotificationListener struct {

--- a/cmd/msggen/main.go
+++ b/cmd/msggen/main.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"github.com/alecthomas/kong"
-	"github.com/squareup/pranadb/msggen"
 	"log"
 	"os"
 	"time"
+
+	"github.com/alecthomas/kong"
+	"github.com/squareup/pranadb/msggen"
 )
 
 type arguments struct {

--- a/cmd/prana/commands/upload_proto.go
+++ b/cmd/prana/commands/upload_proto.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/squareup/pranadb/client"
+	"github.com/squareup/pranadb/errors"
 	"github.com/squareup/pranadb/protos/squareup/cash/pranadb/v1/service"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb"

--- a/cmd/prana/main.go
+++ b/cmd/prana/main.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/squareup/pranadb/common"
 	"time"
+
+	"github.com/squareup/pranadb/common"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/squareup/pranadb/client"

--- a/cmd/pranadb/main.go
+++ b/cmd/pranadb/main.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"github.com/squareup/pranadb/common"
 	"os"
 
+	"github.com/squareup/pranadb/common"
+
 	"github.com/alecthomas/kong"
-	"github.com/alecthomas/kong-hcl/v2"
+	konghcl "github.com/alecthomas/kong-hcl/v2"
 	log "github.com/sirupsen/logrus"
 	"github.com/squareup/pranadb/conf"
 	plog "github.com/squareup/pranadb/log"

--- a/cmd/pranadb/runner_test.go
+++ b/cmd/pranadb/runner_test.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/squareup/pranadb/conf"
 	"github.com/stretchr/testify/require"

--- a/command/command.go
+++ b/command/command.go
@@ -6,15 +6,13 @@ import (
 	"sync/atomic"
 
 	"github.com/alecthomas/participle/v2"
-	"github.com/pkg/errors"
-	"github.com/squareup/pranadb/common"
-	"github.com/squareup/pranadb/protolib"
-
 	"github.com/squareup/pranadb/cluster"
 	"github.com/squareup/pranadb/command/parser"
+	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/errors"
 	"github.com/squareup/pranadb/meta"
 	"github.com/squareup/pranadb/notifier"
-	"github.com/squareup/pranadb/perrors"
+	"github.com/squareup/pranadb/protolib"
 	"github.com/squareup/pranadb/protos/squareup/cash/pranadb/v1/notifications"
 	"github.com/squareup/pranadb/pull"
 	"github.com/squareup/pranadb/pull/exec"
@@ -77,13 +75,13 @@ func (e *Executor) ExecuteSQLStatement(session *sess.Session, sql string) (exec.
 	if err != nil {
 		var perr participle.Error
 		if errors.As(err, &perr) {
-			return nil, perrors.NewInvalidStatementError(err.Error())
+			return nil, errors.NewInvalidStatementError(err.Error())
 		}
 		return nil, err
 	}
 
 	if session.Schema == nil && ast.Use == "" {
-		return nil, perrors.NewSchemaNotInUseError()
+		return nil, errors.NewSchemaNotInUseError()
 	}
 
 	if session.Schema != nil && session.Schema.IsDeleted() {
@@ -142,7 +140,7 @@ func (e *Executor) ExecuteSQLStatement(session *sess.Session, sql string) (exec.
 	case ast.Use != "":
 		return e.execUse(session, ast.Use)
 	}
-	return nil, perrors.Errorf("invalid statement %s", sql)
+	return nil, errors.Errorf("invalid statement %s", sql)
 }
 
 func (e *Executor) CreateSession() *sess.Session {
@@ -189,7 +187,7 @@ func (e *Executor) execPrepare(session *sess.Session, sql string) (exec.PullExec
 	// TODO we should really use the parser to do this
 	sql = strings.ToLower(sql)
 	if strings.Index(sql, "prepare ") != 0 {
-		return nil, perrors.Errorf("in valid prepare command %s", sql)
+		return nil, errors.Errorf("in valid prepare command %s", sql)
 	}
 	sql = sql[8:]
 	return e.pullEngine.PrepareSQLStatement(session, sql)

--- a/command/ddl_runner.go
+++ b/command/ddl_runner.go
@@ -1,14 +1,15 @@
 package command
 
 import (
-	log "github.com/sirupsen/logrus"
-	"github.com/squareup/pranadb/common"
-	"github.com/squareup/pranadb/notifier"
-	"github.com/squareup/pranadb/perrors"
-	"github.com/squareup/pranadb/protos/squareup/cash/pranadb/v1/notifications"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/errors"
+	"github.com/squareup/pranadb/notifier"
+	"github.com/squareup/pranadb/protos/squareup/cash/pranadb/v1/notifications"
 )
 
 const (
@@ -108,7 +109,7 @@ func (d *DDLCommandRunner) HandleNotification(notification notifier.Notification
 	} else {
 		com, ok := d.commands[skey]
 		if !ok {
-			return perrors.Errorf("cannot find command with id %d:%d", ddlInfo.GetOriginatingNodeId(), ddlInfo.GetCommandId())
+			return errors.Errorf("cannot find command with id %d:%d", ddlInfo.GetOriginatingNodeId(), ddlInfo.GetCommandId())
 		}
 		if err := com.OnCommit(); err != nil {
 			return err
@@ -189,7 +190,7 @@ func (d *DDLCommandRunner) getLock(lockName string) error {
 			return nil
 		}
 		if time.Now().Sub(start) > schemaLockAttemptTimeout {
-			return perrors.Errorf("timed out waiting to get ddl schema lock for schema %s", lockName)
+			return errors.Errorf("timed out waiting to get ddl schema lock for schema %s", lockName)
 		}
 		time.Sleep(schemaLockRetryDelay)
 	}

--- a/command/drop_source_command.go
+++ b/command/drop_source_command.go
@@ -1,11 +1,12 @@
 package command
 
 import (
+	"sync"
+
 	"github.com/squareup/pranadb/command/parser"
 	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/errors"
 	"github.com/squareup/pranadb/meta"
-	"github.com/squareup/pranadb/perrors"
-	"sync"
 )
 
 type DropSourceCommand struct {
@@ -72,7 +73,7 @@ func (c *DropSourceCommand) BeforePrepare() error {
 	}
 	consuming := source.GetConsumingMVs()
 	if len(consuming) != 0 {
-		return perrors.NewSourceHasChildrenError(c.sourceInfo.SchemaName, c.sourceInfo.Name, consuming)
+		return errors.NewSourceHasChildrenError(c.sourceInfo.SchemaName, c.sourceInfo.Name, consuming)
 	}
 
 	// Update row in tables table to mark it as pending delete
@@ -134,13 +135,13 @@ func (c *DropSourceCommand) getSourceInfo() (*common.SourceInfo, error) {
 			return nil, err
 		}
 		if ast.Drop == nil && !ast.Drop.Source {
-			return nil, perrors.Errorf("not a drop source command %s", c.sql)
+			return nil, errors.Errorf("not a drop source command %s", c.sql)
 		}
 		c.sourceName = ast.Drop.Name
 	}
 	sourceInfo, ok := c.e.metaController.GetSource(c.schemaName, c.sourceName)
 	if !ok {
-		return nil, perrors.NewUnknownSourceError(c.schemaName, c.sourceName)
+		return nil, errors.NewUnknownSourceError(c.schemaName, c.sourceName)
 	}
 	return sourceInfo, nil
 }

--- a/command/parser/ast.go
+++ b/command/parser/ast.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/squareup/pranadb/command/parser/selector"
-	"github.com/squareup/pranadb/perrors"
+	"github.com/squareup/pranadb/errors"
 
 	"github.com/alecthomas/participle/v2"
 	"github.com/alecthomas/participle/v2/lexer"
@@ -66,7 +66,7 @@ func (c *ColumnDef) ToColumnType() (common.ColumnType, error) {
 	ct, ok := common.ColumnTypesByType[c.Type]
 	if ok {
 		if len(c.Parameters) != 0 {
-			return common.ColumnType{}, perrors.MaybeAddStack(participle.Errorf(c.Pos, ""))
+			return common.ColumnType{}, errors.MaybeAddStack(participle.Errorf(c.Pos, ""))
 		}
 		return ct, nil
 	}

--- a/command/parser/parser.go
+++ b/command/parser/parser.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"regexp"
 
-	"github.com/squareup/pranadb/perrors"
+	"github.com/squareup/pranadb/errors"
 
 	"github.com/alecthomas/participle/v2"
 	"github.com/alecthomas/participle/v2/lexer/stateful"
@@ -48,5 +48,5 @@ func Parse(sql string) (*AST, error) {
 	}
 	ast := &AST{}
 	err := parser.ParseString("", sql, ast)
-	return ast, perrors.MaybeAddStack(err)
+	return ast, errors.MaybeAddStack(err)
 }

--- a/command/parser/selector/selector_test.go
+++ b/command/parser/selector/selector_test.go
@@ -2,8 +2,9 @@ package selector
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
+
+	"github.com/squareup/pranadb/errors"
 
 	"github.com/squareup/pranadb/protos/squareup/cash/pranadb/v1/testproto"
 	"github.com/stretchr/testify/require"

--- a/common/commontest/atomic_bool_test.go
+++ b/common/commontest/atomic_bool_test.go
@@ -1,9 +1,10 @@
 package commontest
 
 import (
+	"testing"
+
 	"github.com/squareup/pranadb/common"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestAtomicBoolSetGet(t *testing.T) {

--- a/common/commontest/decimal_test.go
+++ b/common/commontest/decimal_test.go
@@ -1,9 +1,10 @@
 package commontest
 
 import (
+	"testing"
+
 	"github.com/squareup/pranadb/common"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestDecimalFromString(t *testing.T) {

--- a/common/commontest/expression_test.go
+++ b/common/commontest/expression_test.go
@@ -1,8 +1,9 @@
 package commontest
 
 import (
-	"github.com/squareup/pranadb/common"
 	"testing"
+
+	"github.com/squareup/pranadb/common"
 
 	"github.com/stretchr/testify/require"
 )

--- a/common/commontest/rows_test.go
+++ b/common/commontest/rows_test.go
@@ -2,8 +2,9 @@ package commontest
 
 import (
 	"fmt"
-	"github.com/squareup/pranadb/common"
 	"testing"
+
+	"github.com/squareup/pranadb/common"
 
 	"github.com/stretchr/testify/require"
 )

--- a/common/commontest/util_test.go
+++ b/common/commontest/util_test.go
@@ -1,9 +1,10 @@
 package commontest
 
 import (
+	"testing"
+
 	"github.com/squareup/pranadb/common"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestByteSliceMap(t *testing.T) {

--- a/common/conversion.go
+++ b/common/conversion.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/types"
 )

--- a/common/decimal.go
+++ b/common/decimal.go
@@ -2,7 +2,7 @@ package common
 
 import (
 	"github.com/pingcap/tidb/types"
-	"github.com/squareup/pranadb/perrors"
+	"github.com/squareup/pranadb/errors"
 )
 
 type Decimal struct {
@@ -59,14 +59,14 @@ func (d *Decimal) CompareTo(dec *Decimal) int {
 
 func (d *Decimal) Encode(buffer []byte, precision int, scale int) ([]byte, error) {
 	b, err := d.decimal.WriteBin(precision, scale, buffer)
-	return b, perrors.MaybeAddStack(err)
+	return b, errors.MaybeAddStack(err)
 }
 
 func (d *Decimal) Decode(buffer []byte, offset int, precision int, scale int) (int, error) {
 	mydec := &types.MyDecimal{}
 	binSize, err := mydec.FromBin(buffer[offset:], precision, scale)
 	if err != nil {
-		return 0, perrors.MaybeAddStack(err)
+		return 0, errors.MaybeAddStack(err)
 	}
 	d.decimal = mydec
 	return offset + binSize, nil
@@ -75,7 +75,7 @@ func (d *Decimal) Decode(buffer []byte, offset int, precision int, scale int) (i
 func (d *Decimal) Add(other *Decimal) (*Decimal, error) {
 	result := &types.MyDecimal{}
 	if err := types.DecimalAdd(d.decimal, other.decimal, result); err != nil {
-		return nil, perrors.MaybeAddStack(err)
+		return nil, errors.MaybeAddStack(err)
 	}
 	return NewDecimal(result), nil
 }
@@ -83,7 +83,7 @@ func (d *Decimal) Add(other *Decimal) (*Decimal, error) {
 func (d *Decimal) Subtract(other *Decimal) (*Decimal, error) {
 	result := &types.MyDecimal{}
 	if err := types.DecimalSub(d.decimal, other.decimal, result); err != nil {
-		return nil, perrors.MaybeAddStack(err)
+		return nil, errors.MaybeAddStack(err)
 	}
 	return NewDecimal(result), nil
 }

--- a/common/encoding.go
+++ b/common/encoding.go
@@ -2,10 +2,11 @@ package common
 
 import (
 	"encoding/binary"
-	"github.com/pingcap/parser/mysql"
-	"github.com/squareup/pranadb/perrors"
 	"math"
 	"unsafe"
+
+	"github.com/pingcap/parser/mysql"
+	"github.com/squareup/pranadb/errors"
 )
 
 var littleEndian = binary.LittleEndian
@@ -61,7 +62,7 @@ func AppendDecimalToBuffer(buffer []byte, dec Decimal, precision, scale int) ([]
 func AppendTimestampToBuffer(buffer []byte, ts Timestamp) ([]byte, error) {
 	enc, err := ts.ToPackedUint()
 	if err != nil {
-		return nil, perrors.MaybeAddStack(err)
+		return nil, errors.MaybeAddStack(err)
 	}
 	buffer = AppendUint64ToBufferLE(buffer, enc)
 	return buffer, nil
@@ -147,7 +148,7 @@ func ReadTimestampFromBuffer(buffer []byte, offset int, fsp int8) (val Timestamp
 	ts := Timestamp{}
 	enc, off := ReadUint64FromBufferLE(buffer, offset)
 	if err := ts.FromPackedUint(enc); err != nil {
-		return Timestamp{}, 0, perrors.MaybeAddStack(err)
+		return Timestamp{}, 0, errors.MaybeAddStack(err)
 	}
 	ts.SetType(mysql.TypeTimestamp)
 	ts.SetFsp(fsp)

--- a/common/expression.go
+++ b/common/expression.go
@@ -2,7 +2,7 @@ package common
 
 import (
 	"github.com/pingcap/parser/mysql"
-	"github.com/squareup/pranadb/perrors"
+	"github.com/squareup/pranadb/errors"
 
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/types"
@@ -28,7 +28,7 @@ func (e *Expression) ReturnType(colTypes []ColumnType) (ColumnType, error) {
 			colType := ConvertTiDBTypeToPranaType(op.RetType)
 			e.returnType = &colType
 		default:
-			return UnknownColumnType, perrors.Errorf("unexpected expr type %v", op)
+			return UnknownColumnType, errors.Errorf("unexpected expr type %v", op)
 		}
 	}
 	return *e.returnType, nil
@@ -83,7 +83,7 @@ func NewScalarFunctionExpression(colType ColumnType, funcName string, args ...*E
 	ctx := sessctx.NewDummySessionContext()
 	f, err := expression.NewFunction(ctx, funcName, tiDBType, tiDBArgs...)
 	if err != nil {
-		return nil, perrors.MaybeAddStack(err)
+		return nil, errors.MaybeAddStack(err)
 	}
 	return &Expression{expression: f}, nil
 }
@@ -110,17 +110,17 @@ func (e *Expression) GetColumnIndex() (int, bool) {
 
 func (e *Expression) EvalBoolean(row *Row) (bool, bool, error) {
 	val, null, err := e.expression.EvalInt(nil, row.tRow)
-	return val != 0, null, perrors.MaybeAddStack(err)
+	return val != 0, null, errors.MaybeAddStack(err)
 }
 
 func (e *Expression) EvalInt64(row *Row) (val int64, null bool, err error) {
 	val, null, err = e.expression.EvalInt(nil, row.tRow)
-	return val, null, perrors.MaybeAddStack(err)
+	return val, null, errors.MaybeAddStack(err)
 }
 
 func (e *Expression) EvalFloat64(row *Row) (val float64, null bool, err error) {
 	val, null, err = e.expression.EvalReal(nil, row.tRow)
-	return val, null, perrors.MaybeAddStack(err)
+	return val, null, errors.MaybeAddStack(err)
 }
 
 func (e *Expression) EvalDecimal(row *Row) (Decimal, bool, error) {
@@ -131,7 +131,7 @@ func (e *Expression) EvalDecimal(row *Row) (Decimal, bool, error) {
 	if null {
 		return Decimal{}, true, err
 	}
-	return *NewDecimal(dec), false, perrors.MaybeAddStack(err)
+	return *NewDecimal(dec), false, errors.MaybeAddStack(err)
 }
 
 func (e *Expression) EvalTimestamp(row *Row) (Timestamp, bool, error) {
@@ -142,7 +142,7 @@ func (e *Expression) EvalTimestamp(row *Row) (Timestamp, bool, error) {
 	if null {
 		return Timestamp{}, true, err
 	}
-	return ts, false, perrors.MaybeAddStack(err)
+	return ts, false, errors.MaybeAddStack(err)
 }
 
 func (e *Expression) EvalString(row *Row) (val string, null bool, err error) {

--- a/common/key_encoding.go
+++ b/common/key_encoding.go
@@ -1,8 +1,9 @@
 package common
 
 import (
-	"github.com/squareup/pranadb/perrors"
 	"math"
+
+	"github.com/squareup/pranadb/errors"
 )
 
 /*
@@ -42,7 +43,7 @@ func KeyEncodeString(buffer []byte, val string) []byte {
 func KeyEncodeTimestamp(buffer []byte, val Timestamp) ([]byte, error) {
 	enc, err := val.ToPackedUint()
 	if err != nil {
-		return nil, perrors.MaybeAddStack(err)
+		return nil, errors.MaybeAddStack(err)
 	}
 	buffer = AppendUint64ToBufferBE(buffer, enc)
 	return buffer, nil
@@ -55,13 +56,13 @@ func EncodeKey(key Key, colTypes []ColumnType, keyColIndexes []int, buffer []byt
 		case TypeTinyInt, TypeInt, TypeBigInt:
 			valInt64, ok := value.(int64)
 			if !ok {
-				return nil, perrors.Errorf("expected %v to be int64", value)
+				return nil, errors.Errorf("expected %v to be int64", value)
 			}
 			buffer = KeyEncodeInt64(buffer, valInt64)
 		case TypeDecimal:
 			valDec, ok := value.(Decimal)
 			if !ok {
-				return nil, perrors.Errorf("expected %v to be Decimal", value)
+				return nil, errors.Errorf("expected %v to be Decimal", value)
 			}
 			var err error
 			buffer, err = KeyEncodeDecimal(buffer, valDec, colType.DecPrecision, colType.DecScale)
@@ -71,19 +72,19 @@ func EncodeKey(key Key, colTypes []ColumnType, keyColIndexes []int, buffer []byt
 		case TypeDouble:
 			valFloat64, ok := value.(float64)
 			if !ok {
-				return nil, perrors.Errorf("expected %v to be float64", value)
+				return nil, errors.Errorf("expected %v to be float64", value)
 			}
 			buffer = KeyEncodeFloat64(buffer, valFloat64)
 		case TypeVarchar:
 			valString, ok := value.(string)
 			if !ok {
-				return nil, perrors.Errorf("expected %v to be string", value)
+				return nil, errors.Errorf("expected %v to be string", value)
 			}
 			buffer = KeyEncodeString(buffer, valString)
 		case TypeTimestamp:
 			valTime, ok := value.(Timestamp)
 			if !ok {
-				return nil, perrors.Errorf("expected %v to be Timestamp", value)
+				return nil, errors.Errorf("expected %v to be Timestamp", value)
 			}
 			var err error
 			buffer, err = KeyEncodeTimestamp(buffer, valTime)
@@ -91,7 +92,7 @@ func EncodeKey(key Key, colTypes []ColumnType, keyColIndexes []int, buffer []byt
 				return nil, err
 			}
 		default:
-			return nil, perrors.Errorf("unexpected column type %d", colType)
+			return nil, errors.Errorf("unexpected column type %d", colType)
 		}
 	}
 	return buffer, nil
@@ -137,7 +138,7 @@ func EncodeKeyCol(row *Row, colIndex int, colType ColumnType, buffer []byte) ([]
 			return nil, err
 		}
 	default:
-		return nil, perrors.Errorf("unexpected column type %d", colType)
+		return nil, errors.Errorf("unexpected column type %d", colType)
 	}
 	return buffer, nil
 }

--- a/common/meta.go
+++ b/common/meta.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pkg/errors"
 	"github.com/squareup/pranadb/command/parser/selector"
+	"github.com/squareup/pranadb/errors"
 )
 
 type Type int

--- a/common/panic_handler.go
+++ b/common/panic_handler.go
@@ -1,9 +1,10 @@
 package common
 
 import (
-	log "github.com/sirupsen/logrus"
 	"os"
 	"runtime/debug"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func PanicHandler() {

--- a/common/row_encoding.go
+++ b/common/row_encoding.go
@@ -1,7 +1,7 @@
 package common
 
 import (
-	"github.com/squareup/pranadb/perrors"
+	"github.com/squareup/pranadb/errors"
 )
 
 // Values in rows are typically encoded in little-endian order
@@ -49,7 +49,7 @@ func encodeRowCol(row *Row, colIndex int, colType ColumnType, buffer []byte) ([]
 				return nil, err
 			}
 		default:
-			return nil, perrors.Errorf("unexpected column type %d", colType)
+			return nil, errors.Errorf("unexpected column type %d", colType)
 		}
 	}
 	return buffer, nil
@@ -113,7 +113,7 @@ func DecodeRowWithIgnoredCols(buffer []byte, colTypes []ColumnType, includeCol [
 					rows.AppendTimestampToColumn(colIndex, val)
 				}
 			default:
-				return perrors.Errorf("unexpected column type %d", colType)
+				return errors.Errorf("unexpected column type %d", colType)
 			}
 		}
 		if include {

--- a/common/util.go
+++ b/common/util.go
@@ -2,12 +2,13 @@ package common
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"reflect"
 	"runtime"
 	"sync/atomic"
 	"unsafe"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type ByteSliceMap struct {

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/squareup/pranadb/perrors"
+	"github.com/squareup/pranadb/errors"
 )
 
 const (
@@ -47,82 +47,82 @@ type Config struct {
 
 func (c *Config) Validate() error { //nolint:gocyclo
 	if c.NodeID < 0 {
-		return perrors.NewInvalidConfigurationError("NodeID must be >= 0")
+		return errors.NewInvalidConfigurationError("NodeID must be >= 0")
 	}
 	if c.ClusterID < 0 {
-		return perrors.NewInvalidConfigurationError("ClusterID must be >= 0")
+		return errors.NewInvalidConfigurationError("ClusterID must be >= 0")
 	}
 	if c.NumShards < 1 {
-		return perrors.NewInvalidConfigurationError("NumShards must be >= 1")
+		return errors.NewInvalidConfigurationError("NumShards must be >= 1")
 	}
 	if len(c.KafkaBrokers) == 0 {
-		return perrors.NewInvalidConfigurationError("KafkaBrokers must be specified")
+		return errors.NewInvalidConfigurationError("KafkaBrokers must be specified")
 	}
 	for bName, kb := range c.KafkaBrokers {
 		if kb.ClientType == BrokerClientTypeUnknown {
-			return perrors.NewInvalidConfigurationError(fmt.Sprintf("KafkaBroker %s, invalid ClientType, must be %d or %d",
+			return errors.NewInvalidConfigurationError(fmt.Sprintf("KafkaBroker %s, invalid ClientType, must be %d or %d",
 				bName, BrokerClientFake, BrokerClientDefault))
 		}
 	}
 	if c.NotifierHeartbeatInterval < 1*time.Second {
-		return perrors.NewInvalidConfigurationError(fmt.Sprintf("NotifierHeartbeatInterval must be >= %d", time.Second))
+		return errors.NewInvalidConfigurationError(fmt.Sprintf("NotifierHeartbeatInterval must be >= %d", time.Second))
 	}
 	if c.EnableAPIServer {
 		if len(c.APIServerListenAddresses) == 0 {
-			return perrors.NewInvalidConfigurationError("APIServerListenAddresses must be specified")
+			return errors.NewInvalidConfigurationError("APIServerListenAddresses must be specified")
 		}
 		if c.APIServerSessionTimeout < 1*time.Second {
-			return perrors.NewInvalidConfigurationError(fmt.Sprintf("APIServerSessionTimeout must be >= %d", 1*time.Second))
+			return errors.NewInvalidConfigurationError(fmt.Sprintf("APIServerSessionTimeout must be >= %d", 1*time.Second))
 		}
 		if c.APIServerSessionCheckInterval < 100*time.Millisecond {
-			return perrors.NewInvalidConfigurationError(fmt.Sprintf("APIServerSessionCheckInterval must be >= %d", 100*time.Millisecond))
+			return errors.NewInvalidConfigurationError(fmt.Sprintf("APIServerSessionCheckInterval must be >= %d", 100*time.Millisecond))
 		}
 	}
 	if !c.TestServer {
 		if c.NodeID >= len(c.RaftAddresses) {
-			return perrors.NewInvalidConfigurationError("NodeID must be in the range 0 (inclusive) to len(RaftAddresses) (exclusive)")
+			return errors.NewInvalidConfigurationError("NodeID must be in the range 0 (inclusive) to len(RaftAddresses) (exclusive)")
 		}
 		if c.DataDir == "" {
-			return perrors.NewInvalidConfigurationError("DataDir must be specified")
+			return errors.NewInvalidConfigurationError("DataDir must be specified")
 		}
 		if c.ReplicationFactor < 3 {
-			return perrors.NewInvalidConfigurationError("ReplicationFactor must be >= 3")
+			return errors.NewInvalidConfigurationError("ReplicationFactor must be >= 3")
 		}
 		if len(c.RaftAddresses) < c.ReplicationFactor {
-			return perrors.NewInvalidConfigurationError("Number of RaftAddresses must be >= ReplicationFactor")
+			return errors.NewInvalidConfigurationError("Number of RaftAddresses must be >= ReplicationFactor")
 		}
 		if len(c.NotifListenAddresses) != len(c.RaftAddresses) {
-			return perrors.NewInvalidConfigurationError("Number of RaftAddresses must be same as number of NotifListenerAddresses")
+			return errors.NewInvalidConfigurationError("Number of RaftAddresses must be same as number of NotifListenerAddresses")
 		}
 		if c.EnableAPIServer && len(c.APIServerListenAddresses) != len(c.RaftAddresses) {
-			return perrors.NewInvalidConfigurationError("Number of RaftAddresses must be same as number of APIServerListenAddresses")
+			return errors.NewInvalidConfigurationError("Number of RaftAddresses must be same as number of APIServerListenAddresses")
 		}
 		if c.DataSnapshotEntries < 10 {
-			return perrors.NewInvalidConfigurationError("DataSnapshotEntries must be >= 10")
+			return errors.NewInvalidConfigurationError("DataSnapshotEntries must be >= 10")
 		}
 		if c.DataCompactionOverhead < 5 {
-			return perrors.NewInvalidConfigurationError("DataCompactionOverhead must be >= 5")
+			return errors.NewInvalidConfigurationError("DataCompactionOverhead must be >= 5")
 		}
 		if c.DataCompactionOverhead > c.DataSnapshotEntries {
-			return perrors.NewInvalidConfigurationError("DataSnapshotEntries must be >= DataCompactionOverhead")
+			return errors.NewInvalidConfigurationError("DataSnapshotEntries must be >= DataCompactionOverhead")
 		}
 		if c.SequenceSnapshotEntries < 10 {
-			return perrors.NewInvalidConfigurationError("SequenceSnapshotEntries must be >= 10")
+			return errors.NewInvalidConfigurationError("SequenceSnapshotEntries must be >= 10")
 		}
 		if c.SequenceCompactionOverhead < 5 {
-			return perrors.NewInvalidConfigurationError("SequenceCompactionOverhead must be >= 5")
+			return errors.NewInvalidConfigurationError("SequenceCompactionOverhead must be >= 5")
 		}
 		if c.SequenceCompactionOverhead > c.SequenceSnapshotEntries {
-			return perrors.NewInvalidConfigurationError("SequenceSnapshotEntries must be >= SequenceCompactionOverhead")
+			return errors.NewInvalidConfigurationError("SequenceSnapshotEntries must be >= SequenceCompactionOverhead")
 		}
 		if c.LocksSnapshotEntries < 10 {
-			return perrors.NewInvalidConfigurationError("LocksSnapshotEntries must be >= 10")
+			return errors.NewInvalidConfigurationError("LocksSnapshotEntries must be >= 10")
 		}
 		if c.LocksCompactionOverhead < 5 {
-			return perrors.NewInvalidConfigurationError("LocksCompactionOverhead must be >= 5")
+			return errors.NewInvalidConfigurationError("LocksCompactionOverhead must be >= 5")
 		}
 		if c.LocksCompactionOverhead > c.LocksSnapshotEntries {
-			return perrors.NewInvalidConfigurationError("LocksSnapshotEntries must be >= LocksCompactionOverhead")
+			return errors.NewInvalidConfigurationError("LocksSnapshotEntries must be >= LocksCompactionOverhead")
 		}
 	}
 	return nil

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -2,10 +2,11 @@ package conf
 
 import (
 	"fmt"
-	"github.com/squareup/pranadb/perrors"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/squareup/pranadb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 type configPair struct {
@@ -201,9 +202,9 @@ func TestValidate(t *testing.T) {
 	for _, cp := range invalidConfigs {
 		err := cp.conf.Validate()
 		require.Error(t, err)
-		pe, ok := err.(perrors.PranaError)
+		pe, ok := err.(errors.PranaError)
 		require.True(t, ok)
-		require.Equal(t, perrors.InvalidConfiguration, int(pe.Code))
+		require.Equal(t, errors.InvalidConfiguration, int(pe.Code))
 		require.Equal(t, cp.errMsg, pe.Msg)
 	}
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,10 +1,8 @@
-package perrors
+package errors
 
 import (
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 type ErrorCode int
@@ -100,12 +98,8 @@ func NewPranaError(errorCode ErrorCode, msg string) PranaError {
 	return PranaError{Code: errorCode, Msg: msg}
 }
 
-func Errorf(msgFormat string, args ...interface{}) error {
-	return MaybeAddStack(fmt.Errorf(msgFormat, args...))
-}
-
 func Error(msg string) error {
-	return MaybeAddStack(errors.New(msg))
+	return New(msg)
 }
 
 // PranaError is any kind of error that is exposed to the user via external interfaces like the CLI
@@ -121,7 +115,7 @@ func (u PranaError) Error() string {
 func MaybeAddStack(err error) error {
 	_, ok := err.(PranaError)
 	if !ok {
-		return errors.WithStack(err)
+		return WithStack(err)
 	}
 	return err
 }

--- a/errors/wrap.go
+++ b/errors/wrap.go
@@ -1,0 +1,302 @@
+// Package errors provides an identical API to the popular github.com/pkg/errors package. It also provides several
+// feature enhancements.
+//
+// Stack Traces
+//
+// github.com/pkg/errors includes a stacktrace for every wrapped call. This creates a lot of noise in GAP applications
+// since we prefer to always a wrap an error to ensure a logged error always has a stacktrace. This package attempts
+// to remove stack traces when it can detect the traces have a shared caller. Typically you are left with only the
+// root stack trace.
+package errors
+
+import (
+	stderrors "errors" //nolint: depguard
+	"fmt"
+	"io"
+	"runtime"
+
+	"github.com/pkg/errors" //nolint: depguard
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// github.com/pkg/errors api
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return newStackErr(nil, message)
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return newStackErr(nil, fmt.Sprintf(format, args...))
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is called, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return newStackErr(err, fmt.Sprintf(format, args...))
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return newStackErr(err, message)
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return newStackErr(err, "")
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return newStackErr(err, message)
+}
+
+// WithMessagef annotates err with the format specifier.
+// If err is nil, WithMessagef returns nil.
+func WithMessagef(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return newStackErr(err, fmt.Sprintf(format, args...))
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		// all GAP errors implement Cause, so check if this is the last GAP error
+		if cause.Cause() == nil {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}
+
+// gRPC status errors api
+
+// StatusError returns an error representing c and msg.  If c is OK, returns nil.
+func StatusError(code codes.Code, message string) error {
+	if code == codes.OK {
+		return nil
+	}
+	return newStackErr(status.Error(code, message), "")
+}
+
+// StatusErrorf returns Error(c, fmt.Sprintf(format, a...)).
+func StatusErrorf(code codes.Code, format string, args ...interface{}) error {
+	if code == codes.OK {
+		return nil
+	}
+	return newStackErr(status.Errorf(code, format, args...), "")
+}
+
+// standard go errors api
+
+// Is reports whether any error in err's chain matches target.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements a method Is(error) bool such that Is(target) returns true.
+func Is(err, target error) bool { return stderrors.Is(err, target) }
+
+// As finds the first error in err's chain that matches target, and if so, sets
+// target to that error value and returns true.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error matches target if the error's concrete value is assignable to the value
+// pointed to by target, or if the error has a method As(interface{}) bool such that
+// As(target) returns true. In the latter case, the As method is responsible for
+// setting target.
+//
+// As will panic if target is not a non-nil pointer to either a type that implements
+// error, or to any interface type. As returns false if err is nil.
+func As(err error, target interface{}) bool { return stderrors.As(err, target) }
+
+// Unwrap returns the result of calling the Unwrap method on err, if err's
+// type contains an Unwrap method returning error.
+// Otherwise, Unwrap returns nil.
+func Unwrap(err error) error {
+	return stderrors.Unwrap(err)
+}
+
+type stackErr struct {
+	cause error
+	stack errors.StackTrace
+	msg   string
+}
+
+func newStackErr(cause error, msg string) error {
+	// make a stack trace for the error. remove 2 frames to account for this method and the public api calling method
+	// (e.g Wrapf)
+	stack := errors.New("").(stackTracer).StackTrace()[2:]
+	return &stackErr{
+		cause: cause,
+		stack: stack,
+		msg:   msg,
+	}
+}
+
+func (e *stackErr) Error() string {
+	if e.cause != nil {
+		if e.msg != "" {
+			return e.msg + ": " + e.cause.Error()
+		}
+		return e.cause.Error()
+	}
+	return e.msg
+}
+
+func (e *stackErr) Cause() error {
+	return e.cause
+}
+
+// StackTrace returns non-nil if the error contains a unique StackTrace in the error chain.
+//
+// We aggressively wrap errors to ensure there is always a StackTrace when an error occurs in production. Unfortunately
+// this leads to a lot of redundant StackTraces in the error report if there are multiple wraps. This method attempts
+// to detect redundant StackTraces and only returns unique StackTraces. Typically an error report will only have a
+// single root stack trace. If an error is sent between goroutines there will be a StackTrace per goroutine.
+//
+// Ideally this method would be called something different to make it clear it might filter StackTraces. However, the
+// sentry library reflectively calls this method (thinking it's the pkg/errors library). We want to remove redundant
+// StackTraces from sentry reports as well.
+func (e *stackErr) StackTrace() errors.StackTrace {
+	var cStack errors.StackTrace
+	if sCause, ok := e.cause.(stackTracer); ok {
+		if gCause, ok := e.cause.(*stackErr); ok {
+			// need to special case gapErrs so we don't recursively call this method. it can return nil even if there
+			// is a stacktrace for the cause.
+			cStack = gCause.stack
+		} else {
+			cStack = sCause.StackTrace()
+		}
+	}
+	if cStack == nil || len(cStack) < len(e.stack) {
+		return e.stack
+	}
+	// start at the bottom of the stack (i.e end of list) and walk up the call stack, comparing the program
+	// counters against the cause. stop before the last one of the stack, since it's special
+	for i := 1; i < len(e.stack); i++ {
+		if cStack[len(cStack)-i] != e.stack[len(e.stack)-i] {
+			return e.stack
+		}
+	}
+	// cannot compare the program counters for the top of the stack and instead just compare the function names.
+	if sameFn(cStack[len(cStack)-len(e.stack)], e.stack[0]) {
+		return nil
+	}
+	return e.stack
+}
+
+// sameFn checks if the 2 stack frames are the same function. this explicitly does not check the line number since
+// that does not work for the common error propagation idiom:
+//
+// if err := thing(); err != nil {
+//   return errors.WithStack(err)
+// }
+func sameFn(f1 errors.Frame, f2 errors.Frame) bool {
+	return file(f1) == file(f2) && name(f1) == name(f2)
+}
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func pc(f errors.Frame) uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func file(f errors.Frame) string {
+	fn := runtime.FuncForPC(pc(f))
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(pc(f))
+	return file
+}
+
+// name returns the name of this function, if known.
+func name(f errors.Frame) string {
+	fn := runtime.FuncForPC(pc(f))
+	if fn == nil {
+		return "unknown"
+	}
+	return fn.Name()
+}
+
+// Unwrap provides compatibility for Go 1.13 error chains.
+func (e *stackErr) Unwrap() error { return e.cause }
+
+// nolint:errcheck
+func (e *stackErr) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			if e.cause != nil {
+				fmt.Fprintf(s, "%+v", e.cause)
+			}
+			if e.msg != "" {
+				if e.cause != nil {
+					io.WriteString(s, "\n")
+				}
+				fmt.Fprintf(s, "%s", e.msg)
+			}
+			stack := e.StackTrace()
+			if stack != nil {
+				fmt.Fprintf(s, "%+v", stack)
+			}
+		} else {
+			io.WriteString(s, e.Error())
+		}
+	case 's':
+		io.WriteString(s, e.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", e.Error())
+	}
+}
+
+type stackTracer interface {
+	StackTrace() errors.StackTrace
+}
+
+type causer interface {
+	Cause() error
+}

--- a/kafka/cflt_client.go
+++ b/kafka/cflt_client.go
@@ -4,11 +4,12 @@
 package kafka
 
 import (
-	"github.com/confluentinc/confluent-kafka-go/kafka"
-	log "github.com/sirupsen/logrus"
-	"github.com/squareup/pranadb/perrors"
 	"sync"
 	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	log "github.com/sirupsen/logrus"
+	"github.com/squareup/pranadb/errors"
 )
 
 // Kafka Message Provider implementation that uses the standard Confluent golang client
@@ -94,7 +95,7 @@ func (cmp *ConfluentMessageProvider) GetMessage(pollTimeout time.Duration) (*Mes
 	case kafka.Error:
 		return nil, e
 	default:
-		return nil, perrors.Errorf("unexpected result from poll %+v", e)
+		return nil, errors.Errorf("unexpected result from poll %+v", e)
 	}
 }
 

--- a/kafka/encoders.go
+++ b/kafka/encoders.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/errors"
 	"github.com/squareup/pranadb/protolib"
 	pref "google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/dynamicpb"

--- a/kafka/fake_kafka_test.go
+++ b/kafka/fake_kafka_test.go
@@ -2,13 +2,14 @@ package kafka
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
-	"github.com/squareup/pranadb/common/commontest"
-	"github.com/stretchr/testify/require"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/squareup/pranadb/common/commontest"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetFakeKafkas(t *testing.T) {

--- a/kafka/ingestor.go
+++ b/kafka/ingestor.go
@@ -1,8 +1,9 @@
 package kafka
 
 import (
-	"github.com/squareup/pranadb/perrors"
 	"time"
+
+	"github.com/squareup/pranadb/errors"
 
 	"github.com/squareup/pranadb/common"
 )
@@ -15,7 +16,7 @@ func IngestRows(f *FakeKafka, sourceInfo *common.SourceInfo, colTypes []common.C
 	topicName := sourceInfo.TopicInfo.TopicName
 	topic, ok := f.GetTopic(topicName)
 	if !ok {
-		return perrors.Errorf("cannot find topic %s", topicName)
+		return errors.Errorf("cannot find topic %s", topicName)
 	}
 	timestamp := timestampBase
 	for i := 0; i < rows.RowCount(); i++ {

--- a/kafka/segment_client.go
+++ b/kafka/segment_client.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/segmentio/kafka-go"
-	"github.com/squareup/pranadb/perrors"
+	"github.com/squareup/pranadb/errors"
 )
 
 // Kafka Message Provider implementation that uses the SegmentIO golang client
@@ -150,7 +150,7 @@ func setProperty(cfg *kafka.ReaderConfig, k, v string) error {
 	case "bootstrap.servers":
 		cfg.Brokers = strings.Split(v, ",")
 	default:
-		return perrors.NewInvalidConfigurationError(fmt.Sprintf("unsupported segmentio/kafka-go client option: %s", v))
+		return errors.NewInvalidConfigurationError(fmt.Sprintf("unsupported segmentio/kafka-go client option: %s", v))
 	}
 	return nil
 }

--- a/log/log.go
+++ b/log/log.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/squareup/pranadb/perrors"
+	"github.com/squareup/pranadb/errors"
 )
 
 // Config contains the configuration for the global logger.
@@ -37,7 +37,7 @@ func (cfg *Config) Configure() error {
 	case "json":
 		log.SetFormatter(&log.JSONFormatter{})
 	default:
-		return perrors.NewInvalidConfigurationError("log format must be either text or json")
+		return errors.NewInvalidConfigurationError("log format must be either text or json")
 	}
 	return nil
 }

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -1,8 +1,9 @@
 package meta
 
 import (
-	"github.com/squareup/pranadb/perrors"
 	"sync"
+
+	"github.com/squareup/pranadb/errors"
 
 	"github.com/squareup/pranadb/cluster"
 	"github.com/squareup/pranadb/common"
@@ -172,7 +173,7 @@ func (c *Controller) ExistsMvOrSource(schema *common.Schema, name string) error 
 
 func (c *Controller) existsTable(schema *common.Schema, name string) error {
 	if _, ok := schema.GetTable(name); ok {
-		return perrors.Errorf("table with Name %s already exists in Schema %s", name, schema.Name)
+		return errors.Errorf("table with Name %s already exists in Schema %s", name, schema.Name)
 	}
 	return nil
 }
@@ -220,7 +221,7 @@ func (c *Controller) PersistMaterializedView(mvInfo *common.MaterializedViewInfo
 
 func (c *Controller) checkTableID(tableID uint64) error {
 	if _, ok := c.tableIDs[tableID]; ok {
-		return perrors.Errorf("cannot register. table with id %d already exists", tableID)
+		return errors.Errorf("cannot register. table with id %d already exists", tableID)
 	}
 	return nil
 }
@@ -264,14 +265,14 @@ func (c *Controller) UnregisterSource(schemaName string, sourceName string) erro
 	defer c.lock.Unlock()
 	schema, ok := c.schemas[schemaName]
 	if !ok {
-		return perrors.Errorf("no such schema %s", schemaName)
+		return errors.Errorf("no such schema %s", schemaName)
 	}
 	tbl, ok := schema.GetTable(sourceName)
 	if !ok {
-		return perrors.Errorf("no such source %s", sourceName)
+		return errors.Errorf("no such source %s", sourceName)
 	}
 	if _, ok := tbl.(*common.SourceInfo); !ok {
-		return perrors.Errorf("%s is not a source", tbl)
+		return errors.Errorf("%s is not a source", tbl)
 	}
 	delete(c.tableIDs, tbl.GetTableInfo().ID)
 	schema.DeleteTable(sourceName)
@@ -300,24 +301,24 @@ func (c *Controller) UnregisterMaterializedView(schemaName string, mvName string
 	defer c.lock.Unlock()
 	schema, ok := c.schemas[schemaName]
 	if !ok {
-		return perrors.Errorf("no such schema %s", schemaName)
+		return errors.Errorf("no such schema %s", schemaName)
 	}
 	tbl, ok := schema.GetTable(mvName)
 	if !ok {
-		return perrors.Errorf("no such mv %s", mvName)
+		return errors.Errorf("no such mv %s", mvName)
 	}
 	if _, ok := tbl.(*common.MaterializedViewInfo); !ok {
-		return perrors.Errorf("%s is not a materialized view", tbl)
+		return errors.Errorf("%s is not a materialized view", tbl)
 	}
 	delete(c.tableIDs, tbl.GetTableInfo().ID)
 	schema.DeleteTable(mvName)
 	for _, it := range internalTables {
 		internalTbl, ok := schema.GetTable(it)
 		if !ok {
-			return perrors.Errorf("no such internal table %s", it)
+			return errors.Errorf("no such internal table %s", it)
 		}
 		if _, ok := internalTbl.(*common.InternalTableInfo); !ok {
-			return perrors.Errorf("%s is not an internal table", internalTbl)
+			return errors.Errorf("%s is not an internal table", internalTbl)
 		}
 		delete(c.tableIDs, internalTbl.GetTableInfo().ID)
 		schema.DeleteTable(it)

--- a/meta/schema/loader.go
+++ b/meta/schema/loader.go
@@ -3,9 +3,9 @@ package schema
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/errors"
 	"github.com/squareup/pranadb/meta"
 	"github.com/squareup/pranadb/parplan"
-	"github.com/squareup/pranadb/perrors"
 	"github.com/squareup/pranadb/push"
 	"github.com/squareup/pranadb/push/source"
 )
@@ -68,7 +68,7 @@ func (l *Loader) Start() error {
 			tk := tableKey{info.SchemaName, info.Name}
 			_, ok := mvTables[tk]
 			if ok {
-				return perrors.Errorf("mv %s %s already loaded", info.SchemaName, info.Name)
+				return errors.Errorf("mv %s %s already loaded", info.SchemaName, info.Name)
 			}
 			mvt := &MVTables{mvInfo: info, sequences: []uint64{info.ID}}
 			mvTables[tk] = mvt
@@ -84,7 +84,7 @@ func (l *Loader) Start() error {
 			mvt.sequences = append(mvt.sequences, info.ID)
 			mvt.internalTables = append(mvt.internalTables, info)
 		default:
-			return perrors.Errorf("unknown table kind %s", kind)
+			return errors.Errorf("unknown table kind %s", kind)
 		}
 	}
 

--- a/msggen/generator.go
+++ b/msggen/generator.go
@@ -2,19 +2,18 @@ package msggen
 
 import (
 	"context"
-	"errors"
 	"fmt"
-
 	"math/rand"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/squareup/pranadb/errors"
+
 	kafkaclient "github.com/segmentio/kafka-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/squareup/pranadb/kafka"
-	"github.com/squareup/pranadb/perrors"
 	"github.com/squareup/pranadb/sharder"
 )
 
@@ -41,7 +40,7 @@ func (gm *GenManager) RegisterGenerator(gen MessageGenerator) error {
 	gm.lock.Lock()
 	defer gm.lock.Unlock()
 	if _, ok := gm.generators[gen.Name()]; ok {
-		return perrors.Errorf("generator already registered with name %s", gen.Name())
+		return errors.Errorf("generator already registered with name %s", gen.Name())
 	}
 	gm.generators[gen.Name()] = gen
 	return nil
@@ -58,7 +57,7 @@ func (gm *GenManager) ProduceMessages(genName string, topicName string, partitio
 
 	gen, ok := gm.generators[genName]
 	if !ok {
-		return perrors.Errorf("no generator with registered with name %s", genName)
+		return errors.Errorf("no generator with registered with name %s", genName)
 	}
 
 	msgsSent := int64(0)
@@ -147,7 +146,7 @@ func setProperty(cfg *kafkaclient.Writer, k, v string) error {
 	case "bootstrap.servers":
 		cfg.Addr = kafkaclient.TCP(strings.Split(v, ",")...)
 	default:
-		return perrors.NewInvalidConfigurationError(fmt.Sprintf("unsupported segmentio/kafka-go client option: %s", v))
+		return errors.NewInvalidConfigurationError(fmt.Sprintf("unsupported segmentio/kafka-go client option: %s", v))
 	}
 	return nil
 }

--- a/msggen/generators.go
+++ b/msggen/generators.go
@@ -3,9 +3,10 @@ package msggen
 import (
 	json2 "encoding/json"
 	"fmt"
-	"github.com/squareup/pranadb/kafka"
 	"math/rand"
 	"time"
+
+	"github.com/squareup/pranadb/kafka"
 )
 
 // Example message generators

--- a/notifier/client.go
+++ b/notifier/client.go
@@ -1,13 +1,14 @@
 package notifier
 
 import (
-	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"net"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/golang/protobuf/proto"
+	log "github.com/sirupsen/logrus"
+	"github.com/squareup/pranadb/errors"
 )
 
 const (

--- a/notifier/messages.go
+++ b/notifier/messages.go
@@ -2,8 +2,9 @@ package notifier
 
 import (
 	"fmt"
-	"github.com/squareup/pranadb/common"
 	"net"
+
+	"github.com/squareup/pranadb/common"
 )
 
 type messageType byte

--- a/notifier/notification.go
+++ b/notifier/notification.go
@@ -2,7 +2,7 @@ package notifier
 
 import (
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
+	"github.com/squareup/pranadb/errors"
 
 	"github.com/squareup/pranadb/protos/squareup/cash/pranadb/v1/notifications"
 )

--- a/notifier/notifs_test.go
+++ b/notifier/notifs_test.go
@@ -2,15 +2,16 @@ package notifier
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/squareup/pranadb/common"
-	"github.com/squareup/pranadb/common/commontest"
-	"github.com/squareup/pranadb/protos/squareup/cash/pranadb/v1/notifications"
-	"github.com/stretchr/testify/require"
 	"math/rand"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/common/commontest"
+	"github.com/squareup/pranadb/errors"
+	"github.com/squareup/pranadb/protos/squareup/cash/pranadb/v1/notifications"
+	"github.com/stretchr/testify/require"
 )
 
 // We test primarily with SessionClosedMessage as this allows us to pass simply an arbitrarily sized string so we can

--- a/notifier/server.go
+++ b/notifier/server.go
@@ -5,9 +5,9 @@ import (
 	"net"
 	"sync"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/errors"
 )
 
 const (

--- a/parplan/infoschema.go
+++ b/parplan/infoschema.go
@@ -3,6 +3,7 @@ package parplan
 import (
 	"context"
 	"fmt"
+
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/ddl/placement"

--- a/parplan/parser.go
+++ b/parplan/parser.go
@@ -1,12 +1,13 @@
 package parplan
 
 import (
+	"sort"
+
 	pc_parser "github.com/pingcap/parser"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/charset"
 	driver "github.com/pingcap/tidb/types/parser_driver"
-	"github.com/squareup/pranadb/perrors"
-	"sort"
+	"github.com/squareup/pranadb/errors"
 )
 
 func newParser() *parser {
@@ -31,7 +32,7 @@ func (p *parser) Parse(sql string) (stmt AstHandle, err error) {
 		}
 	}
 	if len(stmtNodes) != 1 {
-		return AstHandle{}, perrors.Errorf("expected 1 statement got %d", len(stmtNodes))
+		return AstHandle{}, errors.Errorf("expected 1 statement got %d", len(stmtNodes))
 	}
 
 	// We gather the param marker expressions then sort them in order of where they appear in the original sql

--- a/parplan/planner.go
+++ b/parplan/planner.go
@@ -2,8 +2,9 @@ package parplan
 
 import (
 	"context"
-	"github.com/squareup/pranadb/perrors"
 	"math"
+
+	"github.com/squareup/pranadb/errors"
 
 	"github.com/squareup/pranadb/sessctx"
 
@@ -73,7 +74,7 @@ func (p *Planner) BuildPhysicalPlan(stmt AstHandle, prepare bool) (core.Physical
 		err = core.Preprocess(p.ctx, stmt.stmt)
 	}
 	if err != nil {
-		return nil, nil, perrors.MaybeAddStack(err)
+		return nil, nil, errors.MaybeAddStack(err)
 	}
 	logicalPlan, err := p.createLogicalPlan(context.TODO(), p.ctx, stmt.stmt, p.is)
 	if err != nil {
@@ -92,7 +93,7 @@ func (p *Planner) createLogicalPlan(ctx context.Context, sessionContext sessionc
 	builder, _ := core.NewPlanBuilder(sessionContext, is, hintProcessor)
 	plan, err := builder.Build(ctx, node)
 	if err != nil {
-		return nil, perrors.MaybeAddStack(err)
+		return nil, errors.MaybeAddStack(err)
 	}
 	logicalPlan, isLogicalPlan := plan.(core.LogicalPlan)
 	if !isLogicalPlan {
@@ -113,7 +114,7 @@ func (p *Planner) createPhysicalPlan(ctx context.Context, sessionContext session
 		}
 		physicalPlan, _, err := p.pullQueryOptimizer.FindBestPlan(sessionContext, logicalPlan)
 		if err != nil {
-			return nil, perrors.MaybeAddStack(err)
+			return nil, errors.MaybeAddStack(err)
 		}
 		return physicalPlan, nil
 	}
@@ -121,7 +122,7 @@ func (p *Planner) createPhysicalPlan(ctx context.Context, sessionContext session
 	flag := uint64(math.MaxUint64)
 	physicalPlan, _, err := core.DoOptimize(ctx, sessionContext, flag, logicalPlan)
 	if err != nil {
-		return nil, perrors.MaybeAddStack(err)
+		return nil, errors.MaybeAddStack(err)
 	}
 	return physicalPlan, nil
 }

--- a/protolib/registry.go
+++ b/protolib/registry.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pkg/errors"
 	"github.com/squareup/pranadb/cluster"
 	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/errors"
 	"github.com/squareup/pranadb/meta"
 	"github.com/squareup/pranadb/notifier"
 	"github.com/squareup/pranadb/protos/squareup/cash/pranadb/v1/notifications"

--- a/protos/squareup/cash/pranadb/v1/notifications/notifications.pb.go
+++ b/protos/squareup/cash/pranadb/v1/notifications/notifications.pb.go
@@ -7,10 +7,11 @@
 package notifications
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/protos/squareup/cash/pranadb/v1/service/service.pb.go
+++ b/protos/squareup/cash/pranadb/v1/service/service.pb.go
@@ -8,6 +8,9 @@ package service
 
 import (
 	context "context"
+	reflect "reflect"
+	sync "sync"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -15,8 +18,6 @@ import (
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	descriptorpb "google.golang.org/protobuf/types/descriptorpb"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/protos/squareup/cash/pranadb/v1/testproto/imports.pb.go
+++ b/protos/squareup/cash/pranadb/v1/testproto/imports.pb.go
@@ -7,11 +7,12 @@
 package testproto
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/protos/squareup/cash/pranadb/v1/testproto/simple.pb.go
+++ b/protos/squareup/cash/pranadb/v1/testproto/simple.pb.go
@@ -7,10 +7,11 @@
 package testproto
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/protos/squareup/cash/pranadb/v1/testproto/testproto.pb.go
+++ b/protos/squareup/cash/pranadb/v1/testproto/testproto.pb.go
@@ -7,10 +7,11 @@
 package testproto
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/pull/exec/project.go
+++ b/pull/exec/project.go
@@ -2,7 +2,7 @@ package exec
 
 import (
 	"github.com/squareup/pranadb/common"
-	"github.com/squareup/pranadb/perrors"
+	"github.com/squareup/pranadb/errors"
 )
 
 type PullProjection struct {
@@ -29,7 +29,7 @@ func NewPullProjection(colNames []string, colTypes []common.ColumnType, projColu
 func (p *PullProjection) GetRows(limit int) (rows *common.Rows, err error) { // nolint: gocyclo
 
 	if limit < 1 {
-		return nil, perrors.Errorf("invalid limit %d", limit)
+		return nil, errors.Errorf("invalid limit %d", limit)
 	}
 
 	rows, err = p.GetChildren()[0].GetRows(limit)
@@ -96,7 +96,7 @@ func (p *PullProjection) GetRows(limit int) (rows *common.Rows, err error) { // 
 					result.AppendTimestampToColumn(j, val)
 				}
 			default:
-				return nil, perrors.Errorf("unexpected column type %d", colType)
+				return nil, errors.Errorf("unexpected column type %d", colType)
 			}
 		}
 

--- a/pull/exec/project_test.go
+++ b/pull/exec/project_test.go
@@ -1,10 +1,11 @@
 package exec
 
 import (
+	"testing"
+
 	"github.com/squareup/pranadb/common"
 	"github.com/squareup/pranadb/common/commontest"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestProjectionOneCol(t *testing.T) {

--- a/pull/exec/remote_executor.go
+++ b/pull/exec/remote_executor.go
@@ -1,12 +1,13 @@
 package exec
 
 import (
-	"errors"
 	"fmt"
-	"github.com/squareup/pranadb/meta"
-	"github.com/squareup/pranadb/perrors"
 	"strings"
 	"sync/atomic"
+
+	"github.com/squareup/pranadb/errors"
+
+	"github.com/squareup/pranadb/meta"
 
 	"github.com/squareup/pranadb/cluster"
 	"github.com/squareup/pranadb/common"
@@ -89,7 +90,7 @@ func (re *RemoteExecutor) Reset() {
 
 func (re *RemoteExecutor) GetRows(limit int) (rows *common.Rows, err error) {
 	if limit < 1 {
-		return nil, perrors.Errorf("invalid limit %d", limit)
+		return nil, errors.Errorf("invalid limit %d", limit)
 	}
 
 	numGetters := len(re.clusterGetters)

--- a/pull/exec/remote_executor_test.go
+++ b/pull/exec/remote_executor_test.go
@@ -2,9 +2,10 @@ package exec
 
 import (
 	"fmt"
-	"github.com/squareup/pranadb/meta"
 	"sync"
 	"testing"
+
+	"github.com/squareup/pranadb/meta"
 
 	"github.com/squareup/pranadb/cluster"
 	"github.com/squareup/pranadb/common"

--- a/pull/exec/select.go
+++ b/pull/exec/select.go
@@ -2,7 +2,7 @@ package exec
 
 import (
 	"github.com/squareup/pranadb/common"
-	"github.com/squareup/pranadb/perrors"
+	"github.com/squareup/pranadb/errors"
 )
 
 const batchSize = 10000
@@ -32,7 +32,7 @@ func NewPullSelect(colNames []string, colTypes []common.ColumnType, predicates [
 func (p *PullSelect) GetRows(limit int) (rows *common.Rows, err error) {
 
 	if limit < 1 {
-		return nil, perrors.Errorf("invalid limit %d", limit)
+		return nil, errors.Errorf("invalid limit %d", limit)
 	}
 
 	var capac int

--- a/pull/exec/select_test.go
+++ b/pull/exec/select_test.go
@@ -1,10 +1,11 @@
 package exec
 
 import (
+	"testing"
+
 	"github.com/squareup/pranadb/common"
 	"github.com/squareup/pranadb/common/commontest"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestSelectOneRow(t *testing.T) {

--- a/pull/exec/sort.go
+++ b/pull/exec/sort.go
@@ -2,10 +2,11 @@ package exec
 
 import (
 	"fmt"
-	"github.com/cznic/mathutil"
-	"github.com/squareup/pranadb/perrors"
 	"sort"
 	"strings"
+
+	"github.com/cznic/mathutil"
+	"github.com/squareup/pranadb/errors"
 
 	"github.com/squareup/pranadb/common"
 )
@@ -38,7 +39,7 @@ func NewPullSort(colNames []string, colTypes []common.ColumnType, desc []bool, s
 
 func (p *PullSort) GetRows(limit int) (*common.Rows, error) { //nolint: gocyclo
 	if limit < 1 {
-		return nil, perrors.Errorf("invalid limit %d", limit)
+		return nil, errors.Errorf("invalid limit %d", limit)
 	}
 
 	if p.rows == nil {
@@ -55,7 +56,7 @@ func (p *PullSort) GetRows(limit int) (*common.Rows, error) { //nolint: gocyclo
 			}
 			if unsorted.RowCount()+rc > orderByMaxRows {
 				// TODO needs test
-				return nil, perrors.Errorf("query with order by cannot return more than %d rows", orderByMaxRows)
+				return nil, errors.Errorf("query with order by cannot return more than %d rows", orderByMaxRows)
 			}
 			unsorted.AppendAll(batch)
 			if rc < queryBatchSize {

--- a/pull/exec/table_scan.go
+++ b/pull/exec/table_scan.go
@@ -1,10 +1,9 @@
 package exec
 
 import (
-	"github.com/pkg/errors"
 	"github.com/squareup/pranadb/cluster"
 	"github.com/squareup/pranadb/common"
-	"github.com/squareup/pranadb/perrors"
+	"github.com/squareup/pranadb/errors"
 	"github.com/squareup/pranadb/table"
 )
 
@@ -103,7 +102,7 @@ func (p *PullTableScan) Reset() {
 
 func (p *PullTableScan) GetRows(limit int) (rows *common.Rows, err error) {
 	if limit < 1 {
-		return nil, perrors.Errorf("invalid limit %d", limit)
+		return nil, errors.Errorf("invalid limit %d", limit)
 	}
 
 	var skipFirst bool

--- a/pull/exec/utils_for_test.go
+++ b/pull/exec/utils_for_test.go
@@ -1,8 +1,9 @@
 package exec
 
 import (
-	"github.com/squareup/pranadb/common/commontest"
 	"testing"
+
+	"github.com/squareup/pranadb/common/commontest"
 
 	"github.com/squareup/pranadb/common"
 )

--- a/pull/exec_builder.go
+++ b/pull/exec_builder.go
@@ -1,11 +1,11 @@
 package pull
 
 import (
-	"errors"
+	"github.com/squareup/pranadb/errors"
+
 	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/planner/util"
 	"github.com/squareup/pranadb/parplan"
-	"github.com/squareup/pranadb/perrors"
 	"github.com/squareup/pranadb/sess"
 
 	"github.com/squareup/pranadb/common"
@@ -112,7 +112,7 @@ func (p *Engine) buildPullDAG(session *sess.Session, plan core.PhysicalPlan, sch
 		tableName := op.Table.Name.L
 		tbl, ok := schema.GetTable(tableName)
 		if !ok {
-			return nil, perrors.Errorf("unknown source or materialized view %s", tableName)
+			return nil, errors.Errorf("unknown source or materialized view %s", tableName)
 		}
 		if len(op.Ranges) > 1 {
 			return nil, errors.New("only one range supported")
@@ -146,7 +146,7 @@ func (p *Engine) buildPullDAG(session *sess.Session, plan core.PhysicalPlan, sch
 		desc, sortByExprs := p.byItemsToDescAndSortExpression(op.ByItems)
 		executor = exec.NewPullSort(colNames, colTypes, desc, sortByExprs)
 	default:
-		return nil, perrors.Errorf("unexpected plan type %T", plan)
+		return nil, errors.Errorf("unexpected plan type %T", plan)
 	}
 
 	var childExecutors []exec.PullExecutor

--- a/push/exec/aggregator.go
+++ b/push/exec/aggregator.go
@@ -4,7 +4,7 @@ import (
 	"github.com/squareup/pranadb/aggfuncs"
 	"github.com/squareup/pranadb/cluster"
 	"github.com/squareup/pranadb/common"
-	"github.com/squareup/pranadb/perrors"
+	"github.com/squareup/pranadb/errors"
 	"github.com/squareup/pranadb/sharder"
 	"github.com/squareup/pranadb/table"
 )
@@ -217,7 +217,7 @@ func (a *Aggregator) calcFullAggregation(prevRow *common.Row, currRow *common.Ro
 				return err
 			}
 		default:
-			return perrors.Errorf("unexpected column type %d", aggFunc.ValueType())
+			return errors.Errorf("unexpected column type %d", aggFunc.ValueType())
 		}
 	}
 	return nil
@@ -287,7 +287,7 @@ func (a *Aggregator) storeAggregateResults(stateHolders map[string]*aggStateHold
 						}
 						resultRows.AppendTimestampToColumn(i, ts)
 					default:
-						return perrors.Errorf("unexpected column type %d", colType)
+						return errors.Errorf("unexpected column type %d", colType)
 					}
 					// TODO!! store extra data
 				}
@@ -330,7 +330,7 @@ func (a *Aggregator) initAggStateWithRow(currRow *common.Row, aggState *aggfuncs
 					return err
 				}
 			default:
-				return perrors.Errorf("unexpected column type %d", colType)
+				return errors.Errorf("unexpected column type %d", colType)
 			}
 		}
 	}
@@ -386,7 +386,7 @@ func (a *Aggregator) evaluateAggFunctions(aggState *aggfuncs.AggState, row *comm
 				return err
 			}
 		default:
-			return perrors.Errorf("unexpected column type %d", aggFunc.ValueType())
+			return errors.Errorf("unexpected column type %d", aggFunc.ValueType())
 		}
 	}
 	return nil

--- a/push/exec/project_test.go
+++ b/push/exec/project_test.go
@@ -1,8 +1,9 @@
 package exec
 
 import (
-	"github.com/squareup/pranadb/common/commontest"
 	"testing"
+
+	"github.com/squareup/pranadb/common/commontest"
 
 	"github.com/stretchr/testify/require"
 

--- a/push/exec/projection.go
+++ b/push/exec/projection.go
@@ -2,8 +2,9 @@ package exec
 
 import (
 	"fmt"
+
 	"github.com/squareup/pranadb/common"
-	"github.com/squareup/pranadb/perrors"
+	"github.com/squareup/pranadb/errors"
 )
 
 type PushProjection struct {
@@ -155,7 +156,7 @@ func (p *PushProjection) calcProjection(row *common.Row, result *common.Rows) er
 				result.AppendTimestampToColumn(j, val)
 			}
 		default:
-			return perrors.Errorf("unexpected column type %d", colType)
+			return errors.Errorf("unexpected column type %d", colType)
 		}
 	}
 
@@ -180,7 +181,7 @@ func (p *PushProjection) calcProjection(row *common.Row, result *common.Rows) er
 			val := row.GetFloat64(colNumber)
 			result.AppendFloat64ToColumn(j, val)
 		default:
-			return perrors.Errorf("unexpected column type %d", colType)
+			return errors.Errorf("unexpected column type %d", colType)
 		}
 	}
 	return nil

--- a/push/exec/select.go
+++ b/push/exec/select.go
@@ -1,8 +1,8 @@
 package exec
 
 import (
-	"errors"
 	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/errors"
 )
 
 type PushSelect struct {

--- a/push/exec/select_test.go
+++ b/push/exec/select_test.go
@@ -1,8 +1,9 @@
 package exec
 
 import (
-	"github.com/squareup/pranadb/common/commontest"
 	"testing"
+
+	"github.com/squareup/pranadb/common/commontest"
 
 	"github.com/stretchr/testify/require"
 

--- a/push/exec/table_exec.go
+++ b/push/exec/table_exec.go
@@ -1,14 +1,14 @@
 package exec
 
 import (
-	"github.com/pkg/errors"
+	"sync"
+
 	"github.com/squareup/pranadb/cluster"
 	"github.com/squareup/pranadb/common"
-	"github.com/squareup/pranadb/perrors"
+	"github.com/squareup/pranadb/errors"
 	"github.com/squareup/pranadb/push/mover"
 	"github.com/squareup/pranadb/push/sched"
 	"github.com/squareup/pranadb/table"
-	"sync"
 )
 
 const lockAndLoadMaxRows = 10
@@ -429,7 +429,7 @@ func (t *TableExecutor) replayChanges(startSeqs map[uint64]int64, endSeqs map[ui
 				return
 			}
 			if len(kvp) != int(numRows) {
-				ch <- perrors.Errorf("node %d expected %d rows got %d start seq %d end seq %d startPrefix %s endPrefix %s",
+				ch <- errors.Errorf("node %d expected %d rows got %d start seq %d end seq %d startPrefix %s endPrefix %s",
 					t.store.GetNodeID(),
 					numRows, len(kvp), startSeq, theEndSeq, common.DumpDataKey(startPrefix), common.DumpDataKey(endPrefix))
 				return

--- a/push/exec/table_scan.go
+++ b/push/exec/table_scan.go
@@ -2,8 +2,9 @@ package exec
 
 import (
 	"fmt"
+
 	"github.com/squareup/pranadb/common"
-	"github.com/squareup/pranadb/perrors"
+	"github.com/squareup/pranadb/errors"
 )
 
 type Scan struct {
@@ -135,7 +136,7 @@ func (t *Scan) appendResultRow(row *common.Row, outRows *common.Rows) error {
 				val := row.GetTimestamp(incomingColIndex)
 				outRows.AppendTimestampToColumn(i, val)
 			default:
-				return perrors.Errorf("unexpected column type %v", colType)
+				return errors.Errorf("unexpected column type %v", colType)
 			}
 		}
 	}

--- a/push/exec/union_all.go
+++ b/push/exec/union_all.go
@@ -1,8 +1,9 @@
 package exec
 
 import (
-	"github.com/squareup/pranadb/common"
 	"sync/atomic"
+
+	"github.com/squareup/pranadb/common"
 )
 
 type UnionAll struct {

--- a/push/exec/utils_for_test.go
+++ b/push/exec/utils_for_test.go
@@ -1,8 +1,9 @@
 package exec
 
 import (
-	"github.com/squareup/pranadb/common/commontest"
 	"testing"
+
+	"github.com/squareup/pranadb/common/commontest"
 
 	"github.com/squareup/pranadb/common"
 )

--- a/push/exec_builder.go
+++ b/push/exec_builder.go
@@ -1,14 +1,15 @@
 package push
 
 import (
-	"errors"
 	"fmt"
+
+	"github.com/squareup/pranadb/errors"
+
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/planner/core"
 	"github.com/squareup/pranadb/aggfuncs"
 	"github.com/squareup/pranadb/common"
 	"github.com/squareup/pranadb/parplan"
-	"github.com/squareup/pranadb/perrors"
 	"github.com/squareup/pranadb/push/exec"
 )
 
@@ -96,7 +97,7 @@ func (m *MaterializedView) buildPushDAG(plan core.PhysicalPlan, aggSequence int,
 				funcType = aggfuncs.FirstRowAggregateFunctionType
 				firstRowFuncs++
 			default:
-				return nil, nil, perrors.Errorf("unexpected aggregate function %s", aggFunc.Name)
+				return nil, nil, errors.Errorf("unexpected aggregate function %s", aggFunc.Name)
 			}
 			colType := common.ConvertTiDBTypeToPranaType(aggFunc.RetTp)
 			af := &exec.AggregateFunctionInfo{
@@ -201,7 +202,7 @@ func (m *MaterializedView) buildPushDAG(plan core.PhysicalPlan, aggSequence int,
 		tableName := phsyIndexScan.Table.Name
 		table, ok := schema.GetTable(tableName.L)
 		if !ok {
-			return nil, nil, perrors.Errorf("cannot find table %s", tableName.L)
+			return nil, nil, errors.Errorf("cannot find table %s", tableName.L)
 		}
 		info := table.GetTableInfo()
 		executor, err = exec.NewScan(tableName.L, info.PrimaryKeyCols)
@@ -209,7 +210,7 @@ func (m *MaterializedView) buildPushDAG(plan core.PhysicalPlan, aggSequence int,
 			return nil, nil, err
 		}
 	default:
-		return nil, nil, perrors.Errorf("unexpected plan type %T", plan)
+		return nil, nil, errors.Errorf("unexpected plan type %T", plan)
 	}
 
 	var childExecutors []exec.PushExecutor
@@ -243,7 +244,7 @@ func (m *MaterializedView) updateSchemas(executor exec.PushExecutor, schema *com
 		tableName := op.TableName
 		tbl, ok := schema.GetTable(tableName)
 		if !ok {
-			return perrors.Errorf("unknown source or materialized view %s", tableName)
+			return errors.Errorf("unknown source or materialized view %s", tableName)
 		}
 		tableInfo := tbl.GetTableInfo()
 		op.SetSchema(tableInfo)

--- a/push/mv.go
+++ b/push/mv.go
@@ -1,13 +1,14 @@
 package push
 
 import (
+	"reflect"
+
 	"github.com/squareup/pranadb/cluster"
 	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/errors"
 	"github.com/squareup/pranadb/parplan"
-	"github.com/squareup/pranadb/perrors"
 	"github.com/squareup/pranadb/push/exec"
 	"github.com/squareup/pranadb/sharder"
-	"reflect"
 )
 
 type MaterializedView struct {
@@ -83,7 +84,7 @@ func (m *MaterializedView) disconnectOrDeleteDataForMV(schema *common.Schema, no
 		tableName := op.TableName
 		tbl, ok := schema.GetTable(tableName)
 		if !ok {
-			return perrors.Errorf("unknown source or materialized view %s", tableName)
+			return errors.Errorf("unknown source or materialized view %s", tableName)
 		}
 		switch tbl := tbl.(type) {
 		case *common.SourceInfo:
@@ -103,7 +104,7 @@ func (m *MaterializedView) disconnectOrDeleteDataForMV(schema *common.Schema, no
 				mv.removeConsumingExecutor(m.Info.Name)
 			}
 		default:
-			return perrors.Errorf("cannot disconnect %s: invalid table type", tbl)
+			return errors.Errorf("cannot disconnect %s: invalid table type", tbl)
 		}
 	case *exec.Aggregator:
 		if disconnect {
@@ -164,7 +165,7 @@ func (m *MaterializedView) connect(executor exec.PushExecutor, addConsuming bool
 			tableName := op.TableName
 			tbl, ok := m.schema.GetTable(tableName)
 			if !ok {
-				return perrors.Errorf("unknown source or materialized view %s", tableName)
+				return errors.Errorf("unknown source or materialized view %s", tableName)
 			}
 			switch tbl := tbl.(type) {
 			case *common.SourceInfo:
@@ -180,7 +181,7 @@ func (m *MaterializedView) connect(executor exec.PushExecutor, addConsuming bool
 				}
 				mv.addConsumingExecutor(m.Info.Name, executor)
 			default:
-				return perrors.Errorf("table scan on %s is not supported", reflect.TypeOf(tbl))
+				return errors.Errorf("table scan on %s is not supported", reflect.TypeOf(tbl))
 			}
 		}
 	case *exec.Aggregator:
@@ -246,7 +247,7 @@ func (m *MaterializedView) getFeedingExecutors(ex exec.PushExecutor) ([]*exec.Ta
 	if ok {
 		tbl, ok := m.schema.GetTable(ts.TableName)
 		if !ok {
-			return nil, nil, perrors.Errorf("unknown source or materialized view %s", ts.TableName)
+			return nil, nil, errors.Errorf("unknown source or materialized view %s", ts.TableName)
 		}
 		switch tbl := tbl.(type) {
 		case *common.SourceInfo:

--- a/push/sched/scheduler.go
+++ b/push/sched/scheduler.go
@@ -1,8 +1,9 @@
 package sched
 
 import (
-	log "github.com/sirupsen/logrus"
 	"sync"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type ShardScheduler struct {

--- a/push/source/message_parser.go
+++ b/push/source/message_parser.go
@@ -6,10 +6,9 @@ import (
 	"reflect"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/errors"
 	"github.com/squareup/pranadb/kafka"
-	"github.com/squareup/pranadb/perrors"
 	"github.com/squareup/pranadb/protolib"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/dynamicpb"
@@ -204,7 +203,7 @@ func (m *MessageParser) evalColumns(rows *common.Rows) error {
 			}
 			rows.AppendTimestampToColumn(i, tsVal)
 		default:
-			return perrors.Errorf("unsupported col type %d", colType.Type)
+			return errors.Errorf("unsupported col type %d", colType.Type)
 		}
 	}
 	return nil
@@ -230,11 +229,11 @@ func getDecoder(registry protolib.Resolver, encoding common.KafkaEncoding) (Deco
 	case common.EncodingProtobuf:
 		desc, err := registry.FindDescriptorByName(protoreflect.FullName(encoding.SchemaName))
 		if err != nil {
-			return nil, perrors.Errorf("could not find protobuf descriptor for %q", encoding.SchemaName)
+			return nil, errors.Errorf("could not find protobuf descriptor for %q", encoding.SchemaName)
 		}
 		msgDesc, ok := desc.(protoreflect.MessageDescriptor)
 		if !ok {
-			return nil, perrors.Errorf("expected to find MessageDescriptor at %q, but was %q", encoding.SchemaName, reflect.TypeOf(msgDesc))
+			return nil, errors.Errorf("expected to find MessageDescriptor at %q, but was %q", encoding.SchemaName, reflect.TypeOf(msgDesc))
 		}
 		decoder = &ProtobufDecoder{desc: msgDesc}
 	default:

--- a/push/source/type_coercer.go
+++ b/push/source/type_coercer.go
@@ -2,11 +2,12 @@ package source
 
 import (
 	"fmt"
-	"github.com/squareup/pranadb/perrors"
 	"math"
 	"reflect"
 	"strconv"
 	"time"
+
+	"github.com/squareup/pranadb/errors"
 
 	"github.com/squareup/pranadb/common"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -21,7 +22,7 @@ func CoerceInt64(val interface{}) (int64, error) {
 		return int64(v), nil
 	case uint64:
 		if v > math.MaxInt64 {
-			return 0, perrors.Errorf("value %d is too large to be coerced to int64", v)
+			return 0, errors.Errorf("value %d is too large to be coerced to int64", v)
 		}
 		return int64(v), nil
 	case uint32:
@@ -32,7 +33,7 @@ func CoerceInt64(val interface{}) (int64, error) {
 		return int64(v), nil
 	case int:
 		if v > math.MaxInt64 {
-			return 0, perrors.Errorf("value %d is too large to be coerced to int64", v)
+			return 0, errors.Errorf("value %d is too large to be coerced to int64", v)
 		}
 		return int64(v), nil
 	case float32:
@@ -47,7 +48,7 @@ func CoerceInt64(val interface{}) (int64, error) {
 	case string:
 		r, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
-			return 0, perrors.Errorf("string value %s cannot be coerced to int64 %v", v, err)
+			return 0, errors.Errorf("string value %s cannot be coerced to int64 %v", v, err)
 		}
 		return r, nil
 	case protoreflect.Enum:
@@ -85,7 +86,7 @@ func CoerceFloat64(val interface{}) (float64, error) {
 	case string:
 		r, err := strconv.ParseFloat(v, 64)
 		if err != nil {
-			return 0, perrors.Errorf("string value %s cannot be coerced to float64 %v", v, err)
+			return 0, errors.Errorf("string value %s cannot be coerced to float64 %v", v, err)
 		}
 		return r, nil
 	default:
@@ -161,5 +162,5 @@ func CoerceTimestamp(val interface{}) (common.Timestamp, error) {
 }
 
 func coerceFailedErr(v interface{}, t string) error {
-	return perrors.Errorf("cannot coerce value %v, type %s to %s", v, reflect.TypeOf(v), t)
+	return errors.Errorf("cannot coerce value %v, type %s to %s", v, reflect.TypeOf(v), t)
 }

--- a/sess/session.go
+++ b/sess/session.go
@@ -1,12 +1,13 @@
 package sess
 
 import (
+	"sync"
+	"sync/atomic"
+
 	"github.com/squareup/pranadb/cluster"
 	"github.com/squareup/pranadb/common"
 	"github.com/squareup/pranadb/parplan"
 	"github.com/squareup/pranadb/pull/exec"
-	"sync"
-	"sync/atomic"
 )
 
 // Session represents a user's session with Prana

--- a/sessctx/ctx.go
+++ b/sessctx/ctx.go
@@ -3,6 +3,7 @@ package sessctx
 import (
 	"context"
 	"fmt"
+
 	"github.com/pingcap/kvproto/pkg/deadlock"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/domain"


### PR DESCRIPTION
It seems like lack of stacktraces has been introducing some difficult debugging so i'm going to just go ahead and blanket wrap all errors with stacks. Didn't do this earlier because doing it using pkg/errors would cause lots of redundant stacktraces. We have gap/errors that was designed to deal with that.

This PR just pulls in the package and gets rid of uses of stdlib errors and pkg/errors. Next PR will introduce error wrapping via a massive find/replace.

```
// Package errors provides an identical API to the popular github.com/pkg/errors package. It also provides several
// feature enhancements.
//
// Stack Traces
//
// github.com/pkg/errors includes a stacktrace for every wrapped call. This creates a lot of noise in GAP applications
// since we prefer to always a wrap an error to ensure a logged error always has a stacktrace. This package attempts
// to remove stack traces when it can detect the traces have a shared caller. Typically you are left with only the
// root stack trace
```