### PR TITLE
Do not run using segmentIO client on CI

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -31,14 +31,11 @@ jobs:
       - name: SQLTests
         run: go test -race -count=1 -timeout 20m -failfast -p 1 -tags confluent ./sqltest
         if: ${{ always() }}
-      - name: Kafka tests using RedPanda and SegmentIO Kafka client
-        run: go test -race -count=1 -timeout 20m -failfast -p 1 -tags integration ./kafkatest -- -kafka-provider=redpanda
-        if: ${{ always() }}
       - name: Kafka tests using RedPanda and Confluent Kafka client
         run: go test -race -count=1 -timeout 20m -failfast -p 1 -tags confluent,integration ./kafkatest -- -kafka-provider=redpanda
         if: ${{ always() }}
-      - name: Kafka tests using Kafka and SegmentIO Kafka client
-        run: go test -race -count=1 -timeout 20m -failfast -p 1 -tags integration ./kafkatest -- -kafka-provider=kafka
+      - name: Kafka tests using Kafka and Confluent Kafka client
+        run: go test -race -count=1 -timeout 20m -failfast -p 1 -tags confluent,integration ./kafkatest -- -kafka-provider=kafka
         if: ${{ always() }}
   slack-on-fail:
     runs-on: [ self-hosted, linux ]


### PR DESCRIPTION
The Segment IO integration test runs result in the most common intermittent failures on the continuous test run on CI.

Segment IO is meant for local development only, as we don't use it when deploying for real. It's also known that the SegmentIO client does not handle rebalancing properly. So I'm removing segment IO from the continuous run and making sure we use the Confluent client for both Kafka and Red Panda.