### PR TITLE
Add a basic buildkite pipeline 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,18 @@
+steps:
+  - label: "Lint Go 🤔"
+    id: "lint-go"
+    command: "golangci-lint run"
+
+  - label: "Lint Protos 🤔"
+    id: "lint-protos"
+    command: "make -C protos lint"
+
+  - label: "Test :golang:"
+    id: "test"
+    command: "go test -race -count=1 -timeout 20m -failfast -p 1 -tags integration ./..."
+
+# notify:
+#   - slack:
+#       channels:
+#         - "#cash-dx-tools-alerts"
+#     if: 'build.state == "failed" && build.branch == pipeline.default_branch'


### PR DESCRIPTION
This adds a parallel Buildkite pipeline using roughly the config from your existing GitHub config. Completely understand if y'all would prefer to continue with GHA, but thought this might be useful to unblock!