### PR TITLE
Add Docker image for prana cli

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,11 +1,18 @@
 ### Build docker image.
 
+**PranaDB**
 ```bash
 cd $PROJECT_DIR
 
 docker build -f docker/Dockerfile -t pranadb:latest . 	
 ```
 
+**Prana CLI**
+```bash
+cd $PROJECT_DIR
+
+docker build -f docker/cli.Dockerfile -t pranadb-cli:latest .
+```
 ### Run locally.
 
 ```bash

--- a/docker/cli.Dockerfile
+++ b/docker/cli.Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:1.17-alpine AS build_base
+
+RUN apk add build-base librdkafka-dev
+
+# Set the Current Working Directory inside the container
+WORKDIR /tmp/pranadb
+
+# We want to populate the module cache based on the go.{mod,sum} files.
+COPY go.mod .
+
+RUN go mod download
+
+COPY . .
+
+# Build the Go app
+# `-tags musl` is required by the confluent kafka library. https://github.com/confluentinc/confluent-kafka-go/issues/454
+RUN go build -o ./out/prana ./cmd/prana
+
+# Start fresh from a smaller image
+FROM alpine:latest
+RUN apk add bash
+
+COPY --from=build_base /tmp/pranadb/out/prana /usr/local/bin
+
+CMD exec /bin/sh -c "trap : TERM INT; (while true; do sleep 1000; done) & wait"
+
+


### PR DESCRIPTION
Adding an image for the Prana CLI commands. This will make it easier to add tooling to connect to Prana.