### PR TITLE
Various changes for cluster stability

### DIFF
--- a/cluster/dragon/nodes_started_sm.go
+++ b/cluster/dragon/nodes_started_sm.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lni/dragonboat/v3/statemachine"
 	"github.com/squareup/pranadb/common"
 	"io"
+	"io/ioutil"
 )
 
 const (
@@ -64,14 +65,9 @@ func (n *nodesStartedSM) SaveSnapshot(writer io.Writer, collection statemachine.
 }
 
 func (n *nodesStartedSM) RecoverFromSnapshot(reader io.Reader, files []statemachine.SnapshotFile, i <-chan struct{}) error {
-	var bytes []byte
-	for len(bytes) < 8 {
-		readBuff := make([]byte, 8)
-		n, err := reader.Read(readBuff)
-		if err != nil {
-			return err
-		}
-		bytes = append(bytes, readBuff[:n]...)
+	bytes, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return err
 	}
 	n.startSequences = bytesToMap(bytes)
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/twmb/murmur3 v1.1.6
 	github.com/uber-go/atomic v0.0.0-00010101000000-000000000000
+	go.uber.org/ratelimit v0.2.0
 	go.uber.org/zap v1.15.0
 	golang.org/x/net v0.0.0-20210323141857-08027d57d8cf // indirect
 	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=
+github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129/go.mod h1:rFgpPQZYZ8vdbc+48xibu8ALc3yeyd64IhHS+PU6Yyg=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
@@ -456,6 +458,8 @@ go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
+go.uber.org/ratelimit v0.2.0 h1:UQE2Bgi7p2B85uP5dC2bbRtig0C+OeNRnNEafLjsLPA=
+go.uber.org/ratelimit v0.2.0/go.mod h1:YYBV4e4naJvhpitQrWJu1vCpgB7CboMe0qhltKt6mUg=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee h1:0mgffUl7nfd+FpvXMVz4IDEaUSmT1ysygQC7qYo7sG4=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=

--- a/push/source/consumer.go
+++ b/push/source/consumer.go
@@ -101,6 +101,7 @@ func (m *MessageConsumer) pollLoop() {
 			m.consumerError(err, true)
 			return
 		}
+
 		if len(messages) != 0 {
 			// This blocks until messages were actually ingested
 			err := m.source.handleMessages(messages, offsetsToCommit, m.scheduler, m.messageParser)


### PR DESCRIPTION
This PR contains a few things
* Removal of recently added checks for all nodes to be started before starting Prana as this prevents rolling and becomes unnecessary with rate limiting
* A currently hardcoded rate limit for source ingestion. Without this, the nodes can easily get overloaded when ingesting messages which results in some nodes not being able to keep up. Rate limiting makes the cluster stable. We will replace this in the future with a configurable limit. But for now, this lets us progress.
* Addition of more logging around cluster start to aid in diagnosing cluster issues
* Diagnostics to show whether data shards are active - this helps in understanding whether shards are doing stuff if the cluster stalls
* Fixes a bug in snapshot recover for nodes started state machine.