### PR TITLE
Make global ingest rate limit configurable on a global level

### DIFF
--- a/cfg/example.conf
+++ b/cfg/example.conf
@@ -55,3 +55,4 @@ notifier-heartbeat-interval       = "30s" // Amount of time between notifier hea
 enable-api-server                 = true // Set to true to enable the API server - needed for CLI access
 api-server-session-timeout        = "30s" // The amount of time before an API server session times out
 api-server-session-check-interval = "5s" // The amount of time between checking for expired API server sessions
+global-ingest-limit-rows-per-sec  = 1000 // The maximum number of rows per second that can be ingested in the broker - ingest will be throttled to this rate. -1 represents no throttling

--- a/cmd/pranadb/runner_test.go
+++ b/cmd/pranadb/runner_test.go
@@ -78,5 +78,6 @@ func createConfigWithAllFields() conf.Config {
 		APIServerSessionCheckInterval: 6 * time.Second,
 		MetricsBind:                   "localhost:9102",
 		EnableMetrics:                 false,
+		GlobalIngestLimitRowsPerSec:   5000,
 	}
 }

--- a/cmd/pranadb/testdata/config.hcl
+++ b/cmd/pranadb/testdata/config.hcl
@@ -48,3 +48,5 @@ kafka-brokers = {
     }
   }
 }
+
+global-ingest-limit-rows-per-sec = 5000

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -17,6 +17,7 @@ const (
 	DefaultNotifierHeartbeatInterval     = 5 * time.Second
 	DefaultAPIServerSessionTimeout       = 30 * time.Second
 	DefaultAPIServerSessionCheckInterval = 5 * time.Second
+	DefaultGlobalIngestLimitRowsPerSec   = 1000
 )
 
 type Config struct {
@@ -50,6 +51,7 @@ type Config struct {
 	LiveEndpointPath              string
 	MetricsBind                   string `help:"Bind address for Prometheus metrics." default:"localhost:9102" env:"METRICS_BIND"`
 	EnableMetrics                 bool
+	GlobalIngestLimitRowsPerSec   int
 }
 
 func (c *Config) Validate() error { //nolint:gocyclo
@@ -146,6 +148,9 @@ func (c *Config) Validate() error { //nolint:gocyclo
 			return errors.NewInvalidConfigurationError("ReadyEndpointPath must be specified")
 		}
 	}
+	if c.GlobalIngestLimitRowsPerSec < -1 || c.GlobalIngestLimitRowsPerSec == 0 {
+		return errors.NewInvalidConfigurationError("GlobalIngestLimitRowsPerSec must be > 0 or -1")
+	}
 	return nil
 }
 
@@ -175,6 +180,7 @@ func NewDefaultConfig() *Config {
 		NotifierHeartbeatInterval:     DefaultNotifierHeartbeatInterval,
 		APIServerSessionTimeout:       DefaultAPIServerSessionTimeout,
 		APIServerSessionCheckInterval: DefaultAPIServerSessionCheckInterval,
+		GlobalIngestLimitRowsPerSec:   DefaultGlobalIngestLimitRowsPerSec,
 	}
 }
 
@@ -183,6 +189,7 @@ func NewTestConfig(fakeKafkaID int64) *Config {
 		NotifierHeartbeatInterval:     DefaultNotifierHeartbeatInterval,
 		APIServerSessionTimeout:       DefaultAPIServerSessionTimeout,
 		APIServerSessionCheckInterval: DefaultAPIServerSessionCheckInterval,
+		GlobalIngestLimitRowsPerSec:   DefaultGlobalIngestLimitRowsPerSec,
 		NodeID:                        0,
 		NumShards:                     10,
 		TestServer:                    true,

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -218,6 +218,18 @@ func invalidReadyEndpointPath() Config {
 	return cnf
 }
 
+func invalidGlobalIngestLimitRowsPerSecZero() Config {
+	cnf := confAllFields
+	cnf.GlobalIngestLimitRowsPerSec = 0
+	return cnf
+}
+
+func invalidGlobalIngestLimitRowsPerNegative() Config {
+	cnf := confAllFields
+	cnf.GlobalIngestLimitRowsPerSec = -10
+	return cnf
+}
+
 var invalidConfigs = []configPair{
 	{"PDB0004 - Invalid configuration: NodeID must be >= 0", invalidNodeIDConf()},
 	{"PDB0004 - Invalid configuration: ClusterID must be >= 0", invalidClusterIDConf()},
@@ -247,6 +259,8 @@ var invalidConfigs = []configPair{
 	{"PDB0004 - Invalid configuration: StartupEndpointPath must be specified", invalidStartupEndpointPath()},
 	{"PDB0004 - Invalid configuration: LiveEndpointPath must be specified", invalidLiveEndpointPath()},
 	{"PDB0004 - Invalid configuration: ReadyEndpointPath must be specified", invalidReadyEndpointPath()},
+	{"PDB0004 - Invalid configuration: GlobalIngestLimitRowsPerSec must be > 0 or -1", invalidGlobalIngestLimitRowsPerSecZero()},
+	{"PDB0004 - Invalid configuration: GlobalIngestLimitRowsPerSec must be > 0 or -1", invalidGlobalIngestLimitRowsPerNegative()},
 }
 
 func TestValidate(t *testing.T) {
@@ -289,4 +303,5 @@ var confAllFields = Config{
 	APIServerListenAddresses:      []string{"addr7", "addr8", "addr9"},
 	APIServerSessionTimeout:       41 * time.Second,
 	APIServerSessionCheckInterval: 6 * time.Second,
+	GlobalIngestLimitRowsPerSec:   3000,
 }


### PR DESCRIPTION
This PR allows a node-global ingest rate limit, in rows per sec, to be configured on the Prana server.