### PR TITLE
Add ability to start PranaDB cluster locally with docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,34 @@ protos:
 .PHONY: clean
 clean:
 	make -C protos clean
+
+docker-image:
+	docker build -f docker/Dockerfile -t pranadb:latest .
+
+start:docker-image
+	docker-compose -f ./local-deployment/docker-compose.yaml up -d --remove-orphans
+
+stop:
+	docker-compose -f ./local-deployment/docker-compose.yaml down
+
+ifeq ($(origin topic), undefined)
+  topic = payments
+endif
+create-topics:
+	docker exec -it broker kafka-topics --create --topic ${topic} --partitions 25 --bootstrap-server localhost:9092
+
+ifeq ($(origin delay), undefined)
+  delay = 10ms
+endif
+ifeq ($(origin num_messages), undefined)
+  num_messages = 1000
+endif
+ifeq ($(origin index_start), undefined)
+  index_start = 0
+endif
+publish-payments:
+	go run cmd/msggen/main.go --generator-name payments --topic-name payments --partitions 25 --delay ${delay} --num-messages ${num_messages} --index-start ${index_start} --kafka-properties "bootstrap.servers"="localhost:9092"
+
+connect:
+	go run ./cmd/prana/ shell --addr=localhost:6584
+

--- a/README.MD
+++ b/README.MD
@@ -286,3 +286,37 @@ pranadb> select * from customer_balances where customer_id=12;
 |12|other|117|5811145.800000000000000000000000000000|
 3 rows returned
 ````
+
+## Using Docker Compose
+
+You can run the same demo using Docker Compose. You can follow the above steps to create sources and materialized views
+and interact with Prana cluster. These are the Make targets to use:
+
+### Start
+```shell
+make start
+```
+Brings up Kafka, Zookeeper, 3 PranaDB containers and PranaDB load runner container.
+
+### Stop
+```shell
+make stop
+```
+
+### Connect
+```shell
+make connect
+```
+Connects to the PranaDB and open a shell session.
+
+### Create Topics
+```shell
+make create-topics
+```
+Creates the `payments` topic.
+
+### Publish random payments
+```shell
+make publish-payments [delay=10ms] [num_messages=1000] [index_start=0]
+```
+Publishes random payments to the `payments` topic. The amount of messages is defined in

--- a/docker/loadrunner.Dockerfile
+++ b/docker/loadrunner.Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:1.17-alpine AS build_base
+
+RUN apk add build-base librdkafka-dev
+
+# Set the Current Working Directory inside the container
+WORKDIR /tmp/pranadb
+
+# We want to populate the module cache based on the go.{mod,sum} files.
+COPY go.mod .
+
+RUN go mod download
+
+COPY . .
+
+RUN go build -tags musl -o ./out/loadrunner ./cmd/loadrunner
+
+# Start fresh from a smaller image
+FROM alpine:latest
+RUN apk add bash
+
+COPY --from=build_base /tmp/pranadb/out/loadrunner /usr/local/bin
+
+CMD exec /bin/sh -c "trap : TERM INT; (while true; do sleep 1000; done) & wait"
+
+

--- a/local-deployment/conf/pranadb.conf
+++ b/local-deployment/conf/pranadb.conf
@@ -1,0 +1,57 @@
+// Example Prana server configuration file
+// Please note that NodeID is not specified in the config file, it is specified on the command line. This allows you to use
+// the same config file for each node in the cluster
+
+cluster-id = 0 // Each node in the same Prana cluster must have the same ClusterID, there can be multiple Prana clusters on your network
+
+// RaftAddresses are the addresses used by Dragonboat to form Raft clusters. They can be local to your network
+raft-addresses = [
+  "pranadb-0:63201",
+  "pranadb-1:63202",
+  "pranadb-2:63203"
+]
+
+// Each node of the cluster listens for notifications from other nodes - these are the addresses they listen at. They can be local to your network
+notif-listen-addresses = [
+  "pranadb-0:63301",
+  "pranadb-1:63302",
+  "pranadb-2:63303"
+]
+
+// These are the addresses the API server listens at on each node - these is used for connecting from clients. They need to be accessible from the client.
+api-server-listen-addresses = [
+  "pranadb-0:6584",
+  "pranadb-1:6585",
+  "pranadb-2:6586"
+]
+
+num-shards         = 30 // The total number of shards in the cluster
+replication-factor = 3 // The number of replicas - each write will be replicated to this many replicas
+data-dir           = "prana-data" // The base directory for storing data
+
+// KafkaBrokers are the config for the Kafka brokers used by Prana
+// - a map of broker name (a string) to the broker config
+kafka-brokers = {
+  testbroker = {
+    client-type = 2, // Client type determines which Kafka client library is used
+    properties  = {
+      // Properties get passed through to the client library
+      "bootstrap.servers": "broker:29092"
+    }
+  }
+}
+
+// It is less likely you will want to change these settings
+
+test-server                       = false // For a real server always set to false
+data-snapshot-entries             = 10000 // The number of data writes before a snapshot is triggered
+data-compaction-overhead          = 2500 // After a snapshot is taken how many writes to retain for main data
+sequence-snapshot-entries         = 1000 // The number of sequence writes before a snapshot is triggered
+sequence-compaction-overhead      = 250 // After a snapshot is taken how many writes to retain for sequences
+locks-snapshot-entries            = 1000 // The number of lock writes before a snapshot is triggered
+locks-compaction-overhead         = 250 // After a snapshot is taken how many writes to retain for locks
+debug                             = false // Set to true to start a profiling server
+notifier-heartbeat-interval       = "30s" // Amount of time between notifier heartbeats
+enable-api-server                 = true // Set to true to enable the API server - needed for CLI access
+api-server-session-timeout        = "30s" // The amount of time before an API server session times out
+api-server-session-check-interval = "5s" // The amount of time between checking for expired API server sessions

--- a/local-deployment/docker-compose.yaml
+++ b/local-deployment/docker-compose.yaml
@@ -1,0 +1,99 @@
+version: "3.9"
+
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.0.1
+    hostname: zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+  broker:
+    image: confluentinc/cp-kafka:7.0.1
+    hostname: broker
+    container_name: broker
+    depends_on:
+      - zookeeper
+    ports:
+      - "29092:29092"
+      - "9092:9092"
+      - "9101:9101"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_JMX_PORT: 9101
+      KAFKA_JMX_HOSTNAME: localhost
+  pranadb0:
+    image: pranadb:latest
+    hostname: pranadb-0
+    container_name: pranadb0
+    command:
+      - "pranadb"
+      - "--config"
+      - "/etc/pranadb-config/pranadb.conf"
+      - "--node-id"
+      - "0"
+    ports:
+      - "63201:63201"
+      - "63301:63301"
+      - "6585:6584"
+      - "9103:9102"
+    volumes:
+      - ${PWD}/local-deployment/conf:/etc/pranadb-config:ro
+      - ./prana-data
+  pranadb1:
+    image: pranadb:latest
+    hostname: pranadb-1
+    container_name: pranadb1
+    command:
+      - "pranadb"
+      - "--config"
+      - "/etc/pranadb-config/pranadb.conf"
+      - "--node-id"
+      - "1"
+    ports:
+      - "63202:63201"
+      - "63302:63301"
+      - "6586:6584"
+      - "9104:9102"
+    volumes:
+      - ${PWD}/local-deployment/conf:/etc/pranadb-config:ro
+      - ./prana-data
+  pranadb2:
+    image: pranadb:latest
+    hostname: pranadb-2
+    container_name: pranadb2
+    command:
+      - "pranadb"
+      - "--config"
+      - "/etc/pranadb-config/pranadb.conf"
+      - "--node-id"
+      - "2"
+    ports:
+      - "63203:63201"
+      - "63303:63301"
+      - "6587:6584"
+      - "9105:9102"
+    volumes:
+      - ${PWD}/local-deployment/conf:/etc/pranadb-config:ro
+      - ./prana-data
+  nginx:
+    image: nginx:latest
+    hostname: pranadb-api
+    container_name: nginx
+    volumes:
+      - ${PWD}/local-deployment/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - pranadb0
+      - pranadb1
+      - pranadb2
+    ports:
+      - "6584:8080"

--- a/local-deployment/nginx/nginx.conf
+++ b/local-deployment/nginx/nginx.conf
@@ -1,0 +1,21 @@
+user  nginx;
+
+events {
+    worker_connections   1000;
+}
+http {
+    include mime.types;
+    default_type  application/octet-stream;
+    upstream pranadb {
+        server pranadb-0:6584;
+        server pranadb-1:6584;
+        server pranadb-2:6584;
+    }
+    server {
+        listen 8080 http2;
+
+        location / {
+            grpc_pass grpc://pranadb;
+        }
+    }
+}


### PR DESCRIPTION
This PR avoids manually having to startup PranaDB in multiple terminals. It starts Kafka with a single broker and 3 PranaDB nodes. It also adds a Make file with targets to interact with the PranaDB cluster and run the demo locally.

- [X] Tested connecting to API port on a single container
- [X] Add nginx as a grpc load balancer with round robin to connect to one of the pranadb nodes.
- [X] End to end test with the Kafka container