### PR TITLE
Remove metrics from message generation

### DIFF
--- a/cmd/msggen/main.go
+++ b/cmd/msggen/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"github.com/alecthomas/kong"
-	"github.com/squareup/pranadb/errors"
-	"github.com/squareup/pranadb/msggen"
 	"log"
 	"os"
 	"time"
+
+	"github.com/alecthomas/kong"
+	"github.com/squareup/pranadb/errors"
+	"github.com/squareup/pranadb/msggen"
 )
 
 type Arguments struct {
@@ -36,10 +37,6 @@ func run(args []string) error {
 		return errors.WithStack(err)
 	}
 	gm, err := msggen.NewGenManager()
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	err = msggen.MetricsServer()
 	if err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
The message generation command is for testing purposes and demo. It doesn't require Kafka publishing metrics. The metrics server also blocks when listening on the metrics port