### PR TITLE
Cleanup mechanism for data created during failed DDL ops

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -60,6 +60,11 @@ type Cluster interface {
 
 	ReleaseLock(prefix string) (bool, error)
 
+	// AddPrefixesToDelete Adds one or more key prefixes to delete from local storage at start-up
+	AddPrefixesToDelete(local bool, prefixes ...[]byte) error
+
+	RemovePrefixesToDelete(local bool, prefixes ...[]byte) error
+
 	Start() error
 
 	Stop() error

--- a/cluster/fake_cluster.go
+++ b/cluster/fake_cluster.go
@@ -334,3 +334,11 @@ func (f *FakeCluster) getInternal(key *kvWrapper) []byte {
 	}
 	return nil
 }
+
+func (f *FakeCluster) AddPrefixesToDelete(local bool, prefixes ...[]byte) error {
+	return nil
+}
+
+func (f *FakeCluster) RemovePrefixesToDelete(local bool, prefixes ...[]byte) error {
+	return nil
+}

--- a/common/sys_table.go
+++ b/common/sys_table.go
@@ -15,6 +15,7 @@ const (
 	OffsetsTableID  = 10
 	ProtobufTableID = 11
 	IndexTableID    = 12
+	ToDeleteTableID = 13
 
 	UserTableIDBase = 1000
 )

--- a/pull/exec/remote_executor_test.go
+++ b/pull/exec/remote_executor_test.go
@@ -192,6 +192,14 @@ type testCluster struct {
 	rowsByShardOrig map[uint64]*common.Rows
 }
 
+func (t *testCluster) AddPrefixesToDelete(local bool, prefixes ...[]byte) error {
+	return nil
+}
+
+func (t *testCluster) RemovePrefixesToDelete(local bool, prefixes ...[]byte) error {
+	return nil
+}
+
 func (t *testCluster) WriteBatchLocally(batch *cluster.WriteBatch) error {
 	return nil
 }


### PR DESCRIPTION
Some DDL operations (e.g. create materialized view) can take some time and in the process data can be written to storage - e.g. data for fill tables, and for the MV state itself during the fill process. 

If the operation then fails, this data can remain orphaned in storage.

This PR introduces a mechanism whereby key prefixes can be stored in a "to_delete" table. These signify ranges of keys that should be deleted on start-up if they are found in this table.

The MV process adds the key ranges it will use at the beginning of the MV create process. It removes them from the to_delete table at successful completion of the operation. If the node crashes and is restarted the key ranges will be found in the to_delete table and the data will be removed.