### PR TITLE
Fix local deployment configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,6 @@ publish-payments:
 connect:
 	go run ./cmd/prana/ shell --addr=localhost:6584
 
+status:
+	docker-compose -f local-deployment/docker-compose.yaml ps -a
+

--- a/local-deployment/conf/pranadb.conf
+++ b/local-deployment/conf/pranadb.conf
@@ -55,3 +55,4 @@ notifier-heartbeat-interval       = "30s" // Amount of time between notifier hea
 enable-api-server                 = true // Set to true to enable the API server - needed for CLI access
 api-server-session-timeout        = "30s" // The amount of time before an API server session times out
 api-server-session-check-interval = "5s" // The amount of time between checking for expired API server sessions
+global-ingest-limit-rows-per-sec  = 2000 // The limit of rows per sec to ingest before throttling


### PR DESCRIPTION
Provide the `global_ingest_limit_rows_per_sec` in the local environment.

- [X] Tested running `make start` then `make status`