### PR TITLE
Enable and expose Raft metrics via Prometheus

### DIFF
--- a/cluster/dragon/dragon.go
+++ b/cluster/dragon/dragon.go
@@ -3,12 +3,13 @@ package dragon
 import (
 	"context"
 	"fmt"
-	"github.com/lni/dragonboat/v3/logger"
-	"github.com/squareup/pranadb/table"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/lni/dragonboat/v3/logger"
+	"github.com/squareup/pranadb/table"
 
 	"github.com/lni/dragonboat/v3/client"
 	log "github.com/sirupsen/logrus"
@@ -269,6 +270,7 @@ func (d *Dragon) Start() error { // nolint:gocyclo
 		RTTMillisecond:      100,
 		RaftAddress:         nodeAddress,
 		SystemEventListener: d,
+		EnableMetrics:       d.cnf.EnableMetrics,
 	}
 
 	nh, err := dragonboat.NewNodeHost(nhc)

--- a/local-deployment/conf/pranadb.conf
+++ b/local-deployment/conf/pranadb.conf
@@ -56,3 +56,4 @@ enable-api-server                 = true // Set to true to enable the API server
 api-server-session-timeout        = "30s" // The amount of time before an API server session times out
 api-server-session-check-interval = "5s" // The amount of time between checking for expired API server sessions
 global-ingest-limit-rows-per-sec  = 2000 // The limit of rows per sec to ingest before throttling
+enable-metrics                    = true // Enable Raft and Pebble metrics

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -3,6 +3,8 @@ package metrics
 import (
 	"net/http"
 
+	"github.com/lni/dragonboat/v3"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
@@ -29,9 +31,16 @@ type Server struct {
 	httpServer *http.Server
 }
 
+type metricServer struct{}
+
+func (ms *metricServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	promhttp.Handler().ServeHTTP(w, r)
+	dragonboat.WriteHealthMetrics(w)
+}
+
 func NewServer(config conf.Config) *Server {
 	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/metrics", &metricServer{})
 	return &Server{
 		config: config,
 		httpServer: &http.Server{


### PR DESCRIPTION
This PR enables Raft metrics capture in Dragonboat from the exsiting `enable-metrics` configuration.

- [x] Tested locally. 

Example output running `curl` on the metrics endpoint:
```
pranadb_process_batch_time_nanos_bucket{node_id="node-0",le="0.005"} 0
pranadb_process_batch_time_nanos_bucket{node_id="node-0",le="0.01"} 0
pranadb_process_batch_time_nanos_bucket{node_id="node-0",le="0.025"} 0
pranadb_process_batch_time_nanos_bucket{node_id="node-0",le="0.05"} 0
pranadb_process_batch_time_nanos_bucket{node_id="node-0",le="0.1"} 0
pranadb_process_batch_time_nanos_bucket{node_id="node-0",le="0.25"} 0
pranadb_process_batch_time_nanos_bucket{node_id="node-0",le="0.5"} 0
pranadb_process_batch_time_nanos_bucket{node_id="node-0",le="1"} 0
pranadb_process_batch_time_nanos_bucket{node_id="node-0",le="2.5"} 0
pranadb_process_batch_time_nanos_bucket{node_id="node-0",le="5"} 0
pranadb_process_batch_time_nanos_bucket{node_id="node-0",le="10"} 0
pranadb_process_batch_time_nanos_bucket{node_id="node-0",le="+Inf"} 267
pranadb_process_batch_time_nanos_sum{node_id="node-0"} 2.509613425e+09
pranadb_process_batch_time_nanos_count{node_id="node-0"} 267
# HELP pranadb_rows_ingested_total counter for number of rows ingested, segmented by source name
# TYPE pranadb_rows_ingested_total counter
pranadb_rows_ingested_total{source="payments"} 320
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 429.94
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1.048576e+06
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 117
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 1.47521536e+08
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.64861354781e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 9.2010496e+08
# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes -1
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# TYPE promhttp_metric_handler_requests_in_flight gauge
promhttp_metric_handler_requests_in_flight 1
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
# TYPE promhttp_metric_handler_requests_total counter
promhttp_metric_handler_requests_total{code="200"} 0
promhttp_metric_handler_requests_total{code="500"} 0
promhttp_metric_handler_requests_total{code="503"} 0
dragonboat_transport_failed_message_connection_attempt_total 0
dragonboat_transport_failed_snapshot_connection_attempt_total 0
dragonboat_transport_message_connections 8
dragonboat_transport_message_send_failure_total 0
dragonboat_transport_message_send_success_total 1574880
dragonboat_transport_received_message_dropped_total 0
dragonboat_transport_received_message_total 1574913
dragonboat_transport_received_snapshot_total 0
dragonboat_transport_snapshot_connections 0
dragonboat_transport_snapshot_send_failure_total 0
dragonboat_transport_snapshot_send_success_total 0
```