### PR TITLE
We need to build the physical plan every time a PS is executed

### DIFF
--- a/parplan/logical_plan_test.go
+++ b/parplan/logical_plan_test.go
@@ -180,7 +180,7 @@ func testLogicalPlan(t *testing.T, query string, expectedPlan string) {
 	require.NoError(t, err)
 	err = planner.preprocess(ast.stmt, false)
 	require.NoError(t, err)
-	logicalPlan, err := planner.createLogicalPlan(planner.sessionCtx, ast.stmt, planner.is)
+	logicalPlan, err := planner.BuildLogicalPlan(ast, false)
 	require.NoError(t, err)
 	planString := logicalPlan.Dump()
 	println(planString)

--- a/sess/session.go
+++ b/sess/session.go
@@ -1,13 +1,13 @@
 package sess
 
 import (
+	"github.com/squareup/pranadb/tidb/planner"
 	"sync"
 	"sync/atomic"
 
 	"github.com/squareup/pranadb/cluster"
 	"github.com/squareup/pranadb/common"
 	"github.com/squareup/pranadb/parplan"
-	"github.com/squareup/pranadb/pull/exec"
 )
 
 // Session represents a user's session with Prana
@@ -73,10 +73,10 @@ func (s *Session) CreateRemotePreparedStatement(id int64, query string) *Prepare
 }
 
 type PreparedStatement struct {
-	ID    int64
-	Query string
-	Dag   exec.PullExecutor
-	Ast   parplan.AstHandle
+	ID          int64
+	Query       string
+	LogicalPlan planner.LogicalPlan
+	Ast         parplan.AstHandle
 }
 
 // Abort should be invoked if the session might have running queries


### PR DESCRIPTION
Previously we were caching the physical plan between successive executions of a PS - however this does not work with some physical plans as they depend on the arguments of the PS - e.g. in the case of a table scan with a range, e.g. for a point get, the values of the range depend on the PS args. We therefore need to build the physical plan each time.