### PR TITLE
Add `make test` target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ protos:
 .PHONY: clean
 clean:
 	make -C protos clean
+	go clean -testcache
+
+.PHONY: test
+test: protos
+	go test -short -timeout 30s ./...
 
 docker-image:
 	docker build -f docker/Dockerfile -t pranadb:latest .


### PR DESCRIPTION
Runs go tests for the entire project, with the `-short` flag set to skip
slow / integration tests.