### PR TITLE
Planner uses indexes

### DIFF
--- a/common/key_encoding.go
+++ b/common/key_encoding.go
@@ -52,48 +52,57 @@ func KeyEncodeTimestamp(buffer []byte, val Timestamp) ([]byte, error) {
 func EncodeKey(key Key, colTypes []ColumnType, keyColIndexes []int, buffer []byte) ([]byte, error) {
 	for i, value := range key {
 		colType := colTypes[keyColIndexes[i]]
-		switch colType.Type {
-		case TypeTinyInt, TypeInt, TypeBigInt:
-			valInt64, ok := value.(int64)
-			if !ok {
-				return nil, errors.Errorf("expected %v to be int64", value)
-			}
-			buffer = KeyEncodeInt64(buffer, valInt64)
-		case TypeDecimal:
-			valDec, ok := value.(Decimal)
-			if !ok {
-				return nil, errors.Errorf("expected %v to be Decimal", value)
-			}
-			var err error
-			buffer, err = KeyEncodeDecimal(buffer, valDec, colType.DecPrecision, colType.DecScale)
-			if err != nil {
-				return nil, errors.WithStack(err)
-			}
-		case TypeDouble:
-			valFloat64, ok := value.(float64)
-			if !ok {
-				return nil, errors.Errorf("expected %v to be float64", value)
-			}
-			buffer = KeyEncodeFloat64(buffer, valFloat64)
-		case TypeVarchar:
-			valString, ok := value.(string)
-			if !ok {
-				return nil, errors.Errorf("expected %v to be string", value)
-			}
-			buffer = KeyEncodeString(buffer, valString)
-		case TypeTimestamp:
-			valTime, ok := value.(Timestamp)
-			if !ok {
-				return nil, errors.Errorf("expected %v to be Timestamp", value)
-			}
-			var err error
-			buffer, err = KeyEncodeTimestamp(buffer, valTime)
-			if err != nil {
-				return nil, errors.WithStack(err)
-			}
-		default:
-			return nil, errors.Errorf("unexpected column type %d", colType)
+		var err error
+		buffer, err = EncodeKeyElement(value, colType, buffer)
+		if err != nil {
+			return nil, err
 		}
+	}
+	return buffer, nil
+}
+
+func EncodeKeyElement(value interface{}, colType ColumnType, buffer []byte) ([]byte, error) {
+	switch colType.Type {
+	case TypeTinyInt, TypeInt, TypeBigInt:
+		valInt64, ok := value.(int64)
+		if !ok {
+			return nil, errors.Errorf("expected %v to be int64", value)
+		}
+		buffer = KeyEncodeInt64(buffer, valInt64)
+	case TypeDecimal:
+		valDec, ok := value.(Decimal)
+		if !ok {
+			return nil, errors.Errorf("expected %v to be Decimal", value)
+		}
+		var err error
+		buffer, err = KeyEncodeDecimal(buffer, valDec, colType.DecPrecision, colType.DecScale)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+	case TypeDouble:
+		valFloat64, ok := value.(float64)
+		if !ok {
+			return nil, errors.Errorf("expected %v to be float64", value)
+		}
+		buffer = KeyEncodeFloat64(buffer, valFloat64)
+	case TypeVarchar:
+		valString, ok := value.(string)
+		if !ok {
+			return nil, errors.Errorf("expected %v to be string", value)
+		}
+		buffer = KeyEncodeString(buffer, valString)
+	case TypeTimestamp:
+		valTime, ok := value.(Timestamp)
+		if !ok {
+			return nil, errors.Errorf("expected %v to be Timestamp", value)
+		}
+		var err error
+		buffer, err = KeyEncodeTimestamp(buffer, valTime)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+	default:
+		return nil, errors.Errorf("unexpected column type %d", colType)
 	}
 	return buffer, nil
 }
@@ -141,4 +150,72 @@ func EncodeKeyCol(row *Row, colIndex int, colType ColumnType, buffer []byte) ([]
 		return nil, errors.Errorf("unexpected column type %d", colType)
 	}
 	return buffer, nil
+}
+
+func DecodeIndexKeyWithIgnoredCols(buffer []byte, colTypes []ColumnType, includeCols []int, indexCols []int, rows *Rows) error {
+	_, offset := ReadUint64FromBufferBE(buffer, 0)
+	_, offset = ReadUint64FromBufferBE(buffer, offset)
+	colIndex := 0
+	for _, indexCol := range indexCols {
+		colType := colTypes[indexCol]
+		include := includeCols == nil || contains(includeCols, indexCol)
+		switch colType.Type {
+		case TypeTinyInt, TypeInt, TypeBigInt:
+			var u uint64
+			u, offset = ReadUint64FromBufferBE(buffer, offset)
+			if include {
+				decoded := u ^ SignBitMask
+				rows.AppendInt64ToColumn(colIndex, int64(decoded))
+			}
+		case TypeDecimal:
+			var val Decimal
+			var err error
+			val, offset, err = ReadDecimalFromBuffer(buffer, offset, colType.DecPrecision, colType.DecScale)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			if include {
+				rows.AppendDecimalToColumn(colIndex, val)
+			}
+		case TypeDouble:
+			var val float64
+			val, offset = ReadFloat64FromBufferLE(buffer, offset)
+			if include {
+				rows.AppendFloat64ToColumn(colIndex, val)
+			}
+		case TypeVarchar:
+			var val string
+			val, offset = ReadStringFromBufferLE(buffer, offset)
+			if include {
+				rows.AppendStringToColumn(colIndex, val)
+			}
+		case TypeTimestamp:
+			var (
+				val Timestamp
+				err error
+			)
+			val, offset, err = ReadTimestampFromBuffer(buffer, offset, colType.FSP)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			if include {
+				rows.AppendTimestampToColumn(colIndex, val)
+			}
+		default:
+			return errors.Errorf("unexpected column type %d", colType)
+		}
+		if include {
+			colIndex++
+		}
+	}
+	return nil
+}
+
+func contains(indexes []int, index int) bool {
+	for _, idx := range indexes {
+		if idx == index {
+			return true
+		}
+	}
+	return false
 }

--- a/parplan/infoschema.go
+++ b/parplan/infoschema.go
@@ -2,6 +2,7 @@ package parplan
 
 import (
 	"fmt"
+
 	"github.com/squareup/pranadb/tidb"
 
 	"github.com/pingcap/parser/model"
@@ -68,25 +69,15 @@ func schemaToInfoSchema(schema *common.Schema) infoschema.InfoSchema {
 		tableName := model.NewCIStr(tableInfo.Name)
 
 		var indexes []*model.IndexInfo
-		var pkCols []*model.IndexColumn
-		for columnIndex := range tableInfo.PrimaryKeyCols {
-			col := &model.IndexColumn{
-				Name:   model.NewCIStr(tableInfo.ColumnNames[columnIndex]),
-				Offset: columnIndex,
-				Length: 0,
-			}
-
-			pkCols = append(pkCols, col)
-		}
 
 		if tableInfo.IndexInfos != nil {
 			for _, indexInfo := range tableInfo.IndexInfos {
 				var indexCols []*model.IndexColumn
-				for columnIndex := range indexInfo.IndexCols {
+				for _, columnIndex := range indexInfo.IndexCols {
 					col := &model.IndexColumn{
 						Name:   model.NewCIStr(tableInfo.ColumnNames[columnIndex]),
 						Offset: columnIndex,
-						Length: 0,
+						Length: -1,
 					}
 
 					indexCols = append(indexCols, col)

--- a/pull/exec/index_reader.go
+++ b/pull/exec/index_reader.go
@@ -1,0 +1,149 @@
+package exec
+
+import (
+	"github.com/squareup/pranadb/cluster"
+	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/errors"
+	"github.com/squareup/pranadb/table"
+)
+
+type PullIndexReader struct {
+	pullExecutorBase
+	tableInfo     *common.TableInfo
+	indexInfo     *common.IndexInfo
+	storage       cluster.Cluster
+	shardID       uint64
+	lastRowPrefix []byte
+	rangeStart    []byte
+	rangeEnd      []byte
+	includeCols   []int
+	covers        bool
+}
+
+var _ PullExecutor = &PullIndexReader{}
+
+/*
+No hidden cols
+*/
+
+func NewPullIndexReader(tableInfo *common.TableInfo,
+	indexInfo *common.IndexInfo,
+	includedCols []int, // Col indexes in the table that are being returned
+	storage cluster.Cluster,
+	shardID uint64,
+	scanRanges []*ScanRange,
+	covers bool) (*PullIndexReader, error) {
+
+	// Calculate the types of the results
+	var resultColTypes []common.ColumnType
+	for _, colIndex := range includedCols {
+		resultColTypes = append(resultColTypes, tableInfo.ColumnTypes[colIndex])
+	}
+
+	rf := common.NewRowsFactory(resultColTypes)
+	base := pullExecutorBase{
+		colTypes:    tableInfo.ColumnTypes,
+		rowsFactory: rf,
+		keyCols:     tableInfo.PrimaryKeyCols,
+	}
+
+	var err error
+	indexShardPrefix := table.EncodeTableKeyPrefix(indexInfo.ID, shardID, 16)
+
+	// The index key in Pebble is:
+	// |shard_id|index_id|index_col0|index_col1|index_col2|...|table_pk_value
+	//
+	// When scanning the index in a range we create a range start and a range end that are a prefix of the index key
+	// The key start, end, don't have to include all, or any, of the index columns
+
+	var rangeStart, rangeEnd []byte
+
+	if scanRanges != nil {
+		rangeStart = append(rangeStart, indexShardPrefix...)
+		rangeEnd = append(rangeEnd, indexShardPrefix...)
+		for i, scanRange := range scanRanges {
+			rangeStart, err = common.EncodeKeyElement(scanRange.LowVal, tableInfo.ColumnTypes[indexInfo.IndexCols[i]], rangeStart)
+			if err != nil {
+				return nil, err
+			}
+			if scanRange.LowExcl {
+				rangeStart = common.IncrementBytesBigEndian(rangeStart)
+			}
+			rangeEnd, err = common.EncodeKeyElement(scanRange.HighVal, tableInfo.ColumnTypes[indexInfo.IndexCols[i]], rangeEnd)
+			if err != nil {
+				return nil, err
+			}
+			if !scanRange.HighExcl {
+				if !allBitsSet(rangeEnd) {
+					rangeEnd = common.IncrementBytesBigEndian(rangeEnd)
+				} else {
+					rangeEnd = nil
+				}
+			}
+		}
+	}
+
+	if rangeStart == nil {
+		rangeStart = indexShardPrefix
+	}
+	if rangeEnd == nil {
+		rangeEnd = table.EncodeTableKeyPrefix(indexInfo.ID+1, shardID, 16)
+	}
+	return &PullIndexReader{
+		pullExecutorBase: base,
+		tableInfo:        tableInfo,
+		indexInfo:        indexInfo,
+		storage:          storage,
+		shardID:          shardID,
+		rangeStart:       rangeStart,
+		rangeEnd:         rangeEnd,
+		includeCols:      includedCols,
+		covers:           covers,
+	}, nil
+}
+
+func (p *PullIndexReader) GetRows(limit int) (rows *common.Rows, err error) {
+	if limit < 1 {
+		return nil, errors.Errorf("invalid limit %d", limit)
+	}
+
+	var skipFirst bool
+	var startPrefix []byte
+	if p.lastRowPrefix == nil {
+		startPrefix = p.rangeStart
+	} else {
+		startPrefix = p.lastRowPrefix
+		skipFirst = true
+	}
+
+	limitToUse := limit
+	if limit != -1 && skipFirst {
+		// We read one extra row as we'll skip the first
+		limitToUse++
+	}
+
+	kvPairs, err := p.storage.LocalScan(startPrefix, p.rangeEnd, limitToUse)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	numRows := len(kvPairs)
+	rows = p.rowsFactory.NewRows(numRows)
+	for i, kvPair := range kvPairs {
+		if i == 0 && skipFirst {
+			continue
+		}
+		if i == numRows-1 {
+			p.lastRowPrefix = kvPair.Key
+		}
+		if p.covers {
+			//Just construct row from key
+			if err := common.DecodeIndexKeyWithIgnoredCols(kvPair.Key, p.tableInfo.ColumnTypes, p.includeCols, p.indexInfo.IndexCols, rows); err != nil {
+				return nil, errors.WithStack(err)
+			}
+		} else {
+			// Lookup row in table
+			// TODO
+		}
+	}
+	return rows, nil
+}

--- a/push/exec/index_exec.go
+++ b/push/exec/index_exec.go
@@ -55,7 +55,7 @@ func (t *IndexExecutor) HandleRows(rowsBatch RowsBatch, ctx *ExecutionContext) e
 
 func (t *IndexExecutor) createKeyBuff(shardID uint64, row *common.Row) ([]byte, error) {
 	keyBuff := table.EncodeTableKeyPrefix(t.IndexInfo.ID, shardID, 32)
-	keyBuff, err := common.EncodeKeyCols(row, t.IndexInfo.IndexCols, t.TableInfo.ColumnTypes, keyBuff)
+	keyBuff, err := common.EncodeIndexKeyCols(row, t.IndexInfo.IndexCols, t.TableInfo.ColumnTypes, keyBuff)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/sqltest/testdata/planner_index_test_data.txt
+++ b/sqltest/testdata/planner_index_test_data.txt
@@ -1,0 +1,11 @@
+dataset:dataset_1 transactions
+1,100,abc
+2,null,def
+3,300,ghi
+4,400,null
+5,500,abc
+6,600,abc
+7,700,abc
+8,800,abc
+9,900,abc
+10,1000,abc

--- a/sqltest/testdata/planner_index_test_data.txt
+++ b/sqltest/testdata/planner_index_test_data.txt
@@ -5,7 +5,7 @@ dataset:dataset_1 transactions
 4,400,null
 5,500,abc
 6,600,abc
-7,700,abc
+7,600,abc
 8,800,abc
 9,900,abc
 10,1000,abc

--- a/sqltest/testdata/planner_index_test_out.txt
+++ b/sqltest/testdata/planner_index_test_out.txt
@@ -25,12 +25,22 @@ create index index1 on transactions (customer_id);
 
 --load data dataset_1;
 
---test with source;
+--test with index;
 
 select customer_id from transactions where customer_id = 600;
 |customer_id|
 |600|
+|600|
+2 rows returned
+
+select customer_id from transactions where customer_id is null;
+|customer_id|
+|null|
 1 rows returned
+
+select customer_id from transactions where customer_id = 1000000;
+|customer_id|
+0 rows returned
 
 drop index index1 on transactions;
 0 rows returned

--- a/sqltest/testdata/planner_index_test_out.txt
+++ b/sqltest/testdata/planner_index_test_out.txt
@@ -1,0 +1,41 @@
+--create topic testtopic;
+use test;
+0 rows returned
+create source transactions(
+    id bigint,
+    customer_id tinyint,
+    col2 varchar,
+    primary key (id)
+) with (
+    brokername = "testbroker",
+    topicname = "testtopic",
+    headerencoding = "json",
+    keyencoding = "json",
+    valueencoding = "json",
+    columnselectors = (
+        meta("key").k0,
+        v1,
+        v2
+    )
+);
+0 rows returned
+
+create index index1 on transactions (customer_id);
+0 rows returned
+
+--load data dataset_1;
+
+--test with source;
+
+select customer_id from transactions where customer_id = 600;
+|customer_id|
+|600|
+1 rows returned
+
+drop index index1 on transactions;
+0 rows returned
+
+drop source transactions;
+0 rows returned
+
+--delete topic testtopic;

--- a/sqltest/testdata/planner_index_test_script.txt
+++ b/sqltest/testdata/planner_index_test_script.txt
@@ -1,0 +1,33 @@
+--create topic testtopic;
+use test;
+create source transactions(
+    id bigint,
+    customer_id tinyint,
+    col2 varchar,
+    primary key (id)
+) with (
+    brokername = "testbroker",
+    topicname = "testtopic",
+    headerencoding = "json",
+    keyencoding = "json",
+    valueencoding = "json",
+    columnselectors = (
+        meta("key").k0,
+        v1,
+        v2
+    )
+);
+
+create index index1 on transactions (customer_id);
+
+--load data dataset_1;
+
+--test with source;
+
+select customer_id from transactions where customer_id = 600;
+
+drop index index1 on transactions;
+
+drop source transactions;
+
+--delete topic testtopic;

--- a/sqltest/testdata/planner_index_test_script.txt
+++ b/sqltest/testdata/planner_index_test_script.txt
@@ -22,9 +22,13 @@ create index index1 on transactions (customer_id);
 
 --load data dataset_1;
 
---test with source;
+--test with index;
 
 select customer_id from transactions where customer_id = 600;
+
+select customer_id from transactions where customer_id is null;
+
+select customer_id from transactions where customer_id = 1000000;
 
 drop index index1 on transactions;
 

--- a/tidb/planner/logical_datasource.go
+++ b/tidb/planner/logical_datasource.go
@@ -19,6 +19,10 @@ package planner
 
 import (
 	"fmt"
+	"math"
+	"sort"
+	"strings"
+
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
@@ -33,9 +37,6 @@ import (
 	"github.com/squareup/pranadb/tidb/util/logutil"
 	"github.com/squareup/pranadb/tidb/util/ranger"
 	"go.uber.org/zap"
-	"math"
-	"sort"
-	"strings"
 )
 
 // LogicalDataSource represents a tableScan without condition push down.
@@ -111,10 +112,10 @@ func (ds *LogicalDataSource) buildTableScan() LogicalPlan {
 	return ts
 }
 
-func (ds *LogicalDataSource) buildIndexScan(path *util.AccessPath) LogicalPlan {
+func (ds *LogicalDataSource) buildIndexScan(path *util.AccessPath, isDoubleRead bool) LogicalPlan {
 	is := LogicalIndexScan{
 		Source:         ds,
-		IsDoubleRead:   false,
+		IsDoubleRead:   isDoubleRead,
 		Index:          path.Index,
 		FullIdxCols:    path.FullIdxCols,
 		FullIdxColLens: path.FullIdxColLens,
@@ -138,9 +139,8 @@ func (ds *LogicalDataSource) Convert2Scans() (scans []LogicalPlan) {
 			path.IdxCols, path.IdxColLens = expression.IndexInfo2PrefixCols(ds.Columns, ds.schema.Columns, path.Index)
 			// If index columns can cover all of the needed columns, we can use a IndexGather + IndexScan.
 			if ds.isCoveringIndex(ds.schema.Columns, path.FullIdxCols, path.FullIdxColLens, ds.tableInfo) {
-				scans = append(scans, ds.buildIndexScan(path))
+				scans = append(scans, ds.buildIndexScan(path, false))
 			}
-			// TODO: If index columns can not cover the schema, use IndexLookUpGather.
 		}
 	}
 	return scans
@@ -467,6 +467,21 @@ func (ds *LogicalDataSource) isCoveringIndex(columns, indexColumns []*expression
 		}
 	}
 	return true
+}
+
+func (ds *LogicalDataSource) isPartiallyCoveringIndex(columns, indexColumns []*expression.Column, idxColLens []int, tblInfo *model.TableInfo) bool {
+	for _, col := range columns {
+		if tblInfo.PKIsHandle && mysql.HasPriKeyFlag(col.RetType.Flag) {
+			continue
+		}
+		if col.ID == model.ExtraHandleID {
+			continue
+		}
+		if indexColumns[0] != nil && col.Equal(nil, indexColumns[0]) {
+			return true
+		}
+	}
+	return false
 }
 
 func indexCoveringCol(col *expression.Column, indexCols []*expression.Column, idxColLens []int) bool {

--- a/tidb/planner/physical_indexscan.go
+++ b/tidb/planner/physical_indexscan.go
@@ -58,6 +58,8 @@ type PhysicalIndexScan struct {
 	KeepOrder bool
 
 	NeedCommonHandle bool
+
+	Covers bool
 }
 
 // Init initializes PhysicalIndexScan.
@@ -90,6 +92,7 @@ func (is *PhysicalIndexScan) initSchema(idxExprCols []*expression.Column, isDoub
 		}
 	}
 	is.NeedCommonHandle = is.Table.IsCommonHandle
+	is.Covers = !isDoubleRead
 
 	if is.NeedCommonHandle {
 		for i := len(is.Index.Columns); i < len(idxExprCols); i++ {


### PR DESCRIPTION
TODO: For partially-covering indexes, have the index reader do a row lookup from the originating table. Will do in a follow-up PR. Also, indexes currently do not contain the PK value for the corresponding row in the originating table, which will also need to be fixed in the next PR.