### PR TITLE
Set started to false when there is an error

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -72,8 +72,8 @@ func (s *Server) startServer(list net.Listener) {
 	err := s.gsrv.Serve(list) //nolint:ifshort
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	s.started = false
 	if err != nil {
+		s.started = false
 		log.Errorf("grpc server listen failed: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes #331
Started must be set to false when there is an error starting server.