### PR TITLE
Implement DESCRIBE statement

### DIFF
--- a/command/parser/ast.go
+++ b/command/parser/ast.go
@@ -160,9 +160,10 @@ type AST struct {
 	Select  string // Unaltered SELECT statement, if any.
 	Prepare string // Unaltered PREPARE statement, if any.
 
-	Use     string   `(  "USE" @Ident`
-	Execute *Execute ` | "EXECUTE" @@`
-	Drop    *Drop    ` | "DROP" @@ `
-	Create  *Create  ` | "CREATE" @@ `
-	Show    *Show    ` | "SHOW" @@ ) ";"?`
+	Use      string   `(  "USE" @Ident`
+	Execute  *Execute ` | "EXECUTE" @@`
+	Drop     *Drop    ` | "DROP" @@ `
+	Create   *Create  ` | "CREATE" @@ `
+	Show     *Show    ` | "SHOW" @@ `
+	Describe string   ` | "DESCRIBE" @Ident ) ";"?`
 }

--- a/command/parser/ast_test.go
+++ b/command/parser/ast_test.go
@@ -107,6 +107,10 @@ func TestParse(t *testing.T) {
 			"ExecutePreparedStatementNoArgs", `EXECUTE 8`,
 			&AST{Execute: &Execute{PsID: 8}}, "",
 		},
+		{
+			"Describe", `DESCRIBE foo`,
+			&AST{Describe: "foo"}, "",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/common/meta.go
+++ b/common/meta.go
@@ -46,6 +46,28 @@ func (t *Type) Capture(tokens []string) error {
 	return nil
 }
 
+func (t Type) String() string {
+	// TODO: consider using Go's stringer tool to generate this mapping.
+	switch t {
+	case TypeTinyInt:
+		return "tinyint"
+	case TypeInt:
+		return "int"
+	case TypeBigInt:
+		return "bigint"
+	case TypeDouble:
+		return "double"
+	case TypeDecimal:
+		return "decimal"
+	case TypeVarchar:
+		return "varchar"
+	case TypeTimestamp:
+		return "timestamp"
+	case TypeUnknown:
+	}
+	return "unknown"
+}
+
 var (
 	TinyIntColumnType   = ColumnType{Type: TypeTinyInt}
 	IntColumnType       = ColumnType{Type: TypeInt}
@@ -112,6 +134,18 @@ type ColumnType struct {
 	FSP          int8 // fractional seconds precision for time types
 }
 
+func (t *ColumnType) String() string {
+	typeName := t.Type.String()
+	switch t.Type {
+	case TypeDecimal:
+		return fmt.Sprintf("%s(%d, %d)", typeName, t.DecPrecision, t.DecScale)
+	case TypeTimestamp:
+		return fmt.Sprintf("%s(%d)", typeName, t.FSP)
+	default:
+	}
+	return typeName
+}
+
 type TableInfo struct {
 	ID             uint64
 	SchemaName     string
@@ -128,6 +162,15 @@ func (i *TableInfo) GetTableInfo() *TableInfo { return i }
 
 func (i *TableInfo) String() string {
 	return fmt.Sprintf("table[name=%s.%s,id=%d]", i.SchemaName, i.Name, i.ID)
+}
+
+func (i *TableInfo) IsPrimaryKey(colIndex int) bool {
+	for _, pkColIdx := range i.PrimaryKeyCols {
+		if pkColIdx == colIndex {
+			return true
+		}
+	}
+	return false
 }
 
 type IndexInfo struct {

--- a/common/meta_test.go
+++ b/common/meta_test.go
@@ -1,0 +1,66 @@
+package common
+
+import "testing"
+
+func TestColumnType_String(t *testing.T) {
+	type fields struct {
+		Type         Type
+		DecPrecision int
+		DecScale     int
+		FSP          int8
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name:   "tiny int",
+			fields: fields{Type: TypeTinyInt},
+			want:   "tinyint",
+		},
+		{
+			name:   "int",
+			fields: fields{Type: TypeInt},
+			want:   "int",
+		},
+		{
+			name:   "big int",
+			fields: fields{Type: TypeBigInt},
+			want:   "bigint",
+		},
+		{
+			name:   "double",
+			fields: fields{Type: TypeDouble},
+			want:   "double",
+		},
+		{
+			name:   "decimal",
+			fields: fields{Type: TypeDecimal, DecPrecision: 4, DecScale: 8},
+			want:   "decimal(4, 8)",
+		},
+		{
+			name:   "varchar",
+			fields: fields{Type: TypeVarchar},
+			want:   "varchar",
+		},
+		{
+			name:   "timestamp",
+			fields: fields{Type: TypeTimestamp, FSP: 6},
+			want:   "timestamp(6)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &ColumnType{
+				Type:         tt.fields.Type,
+				DecPrecision: tt.fields.DecPrecision,
+				DecScale:     tt.fields.DecScale,
+				FSP:          tt.fields.FSP,
+			}
+			if got := tr.String(); got != tt.want {
+				t.Errorf("ColumnType.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/sqltest/testdata/describe_test_out.txt
+++ b/sqltest/testdata/describe_test_out.txt
@@ -1,0 +1,69 @@
+use test;
+0 rows returned
+
+describe foo;
+Failed to execute statement: PDB0019 - Unknown source or materialized view: test.foo
+
+--create topic testtopic;
+
+create source test_source(
+    col0 bigint,
+    col1 tinyint,
+    col2 int,
+    col3 double,
+    col4 decimal(10, 2),
+    col5 varchar,
+    col6 timestamp(6),
+    primary key (col0)
+) with (
+    brokername = "testbroker",
+    topicname = "testtopic",
+    headerencoding = "json",
+    keyencoding = "json",
+    valueencoding = "json",
+    columnselectors = (
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
+    )
+);
+0 rows returned
+describe test_source;
+|field|type|key|
+|col0|bigint|pk|
+|col1|tinyint||
+|col2|int||
+|col3|double||
+|col4|decimal(10, 2)||
+|col5|varchar||
+|col6|timestamp(6)||
+7 rows returned
+
+create materialized view test_mv as select * from test_source;
+0 rows returned
+describe test_mv;
+|field|type|key|
+|col0|bigint|pk|
+|col1|tinyint||
+|col2|int||
+|col3|double||
+|col4|decimal(10, 2)||
+|col5|varchar||
+|col6|timestamp(6)||
+7 rows returned
+
+drop materialized view test_mv;
+0 rows returned
+describe test_mv;
+Failed to execute statement: PDB0019 - Unknown source or materialized view: test.test_mv
+
+drop source test_source;
+0 rows returned
+describe test_source;
+Failed to execute statement: PDB0019 - Unknown source or materialized view: test.test_source
+
+--delete topic testtopic;

--- a/sqltest/testdata/describe_test_script.txt
+++ b/sqltest/testdata/describe_test_script.txt
@@ -1,0 +1,43 @@
+use test;
+
+describe foo;
+
+--create topic testtopic;
+
+create source test_source(
+    col0 bigint,
+    col1 tinyint,
+    col2 int,
+    col3 double,
+    col4 decimal(10, 2),
+    col5 varchar,
+    col6 timestamp(6),
+    primary key (col0)
+) with (
+    brokername = "testbroker",
+    topicname = "testtopic",
+    headerencoding = "json",
+    keyencoding = "json",
+    valueencoding = "json",
+    columnselectors = (
+        meta("key").k0,
+        v1,
+        v2,
+        v3,
+        v4,
+        v5,
+        v6
+    )
+);
+describe test_source;
+
+create materialized view test_mv as select * from test_source;
+describe test_mv;
+
+drop materialized view test_mv;
+describe test_mv;
+
+drop source test_source;
+describe test_source;
+
+--delete topic testtopic;


### PR DESCRIPTION
Adds a DESCRIBE statement that works for sources and materialized views.

The command takes the name of a source/MV in the current scope and
returns a description of every column (its name, type, and whether it's
a PK or not).

Closes #190 