### PR TITLE
fix missing done

### DIFF
--- a/cmd/pranadb/main.go
+++ b/cmd/pranadb/main.go
@@ -78,6 +78,7 @@ func (r *runner) waitForShutdown() {
 		} else {
 			logger.Info("Prana server stopped")
 		}
+		wg.Done()
 	}()
 	wg.Wait()
 }


### PR DESCRIPTION
fix missing `wg.Done()` 
with out this pranadb process is not terminated properly.

pranadb is not properly exit when it got a signal.
it may be no problem in docker container, but always need to `kill -9 <pid>` in non-container environment.