### PR TITLE
Issue#202: Specify TimestampFormat in logger

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -14,7 +14,7 @@ type Config struct {
 	File   string `help:"File to direct logs to. If left blank, or '-', logs will go to stdout" default:"-"`
 }
 
-const TimestampFormat = "2006-01-02 15:04:05.99999"
+const TimestampFormat = "2006-01-02 15:04:05.999999"
 
 // Configure the global logger
 func (cfg *Config) Configure() error {

--- a/log/log.go
+++ b/log/log.go
@@ -14,6 +14,8 @@ type Config struct {
 	File   string `help:"File to direct logs to. If left blank, or '-', logs will go to stdout" default:"-"`
 }
 
+const TimestampFormat = "2006-01-02 15:04:05.99999"
+
 // Configure the global logger
 func (cfg *Config) Configure() error {
 	if cfg.File != "" && cfg.File != "-" {
@@ -32,10 +34,9 @@ func (cfg *Config) Configure() error {
 	}
 	switch cfg.Format {
 	case "text":
-		// default, do nothing
-		break
+		log.SetFormatter(&log.TextFormatter{TimestampFormat: TimestampFormat, FullTimestamp: true})
 	case "json":
-		log.SetFormatter(&log.JSONFormatter{})
+		log.SetFormatter(&log.JSONFormatter{TimestampFormat: TimestampFormat})
 	default:
 		return errors.NewInvalidConfigurationError("log format must be either text or json")
 	}


### PR DESCRIPTION
Config `logrus` to use `TimestampFormat` like `2006-01-02 15:04:05.999999` for both `text` and `json`, which is aligned with the raft log. Closes #202 

After this change:
```
DEBU[2022-05-11 12:26:36.368961] Checking constant shards: 30                 
DEBU[2022-05-11 12:26:36.369329] value for num-shards found in storage: 30    
2022-05-11 12:26:36.369479 I | config: using default EngineConfig
2022-05-11 12:26:36.369502 I | config: using default LogDBConfig
```