### PR TITLE
Planner uses IndexScan for partially-covering indexes

### DIFF
--- a/common/key_encoding.go
+++ b/common/key_encoding.go
@@ -175,7 +175,6 @@ func DecodeIndexKeyWithIgnoredCols(buffer []byte, offset int, colTypes []ColumnT
 	for _, indexCol := range indexCols {
 		colType := colTypes[indexCol]
 		include := false
-		//include := includeCols == nil || Contains(includeCols, indexCol)
 		for i, includeCol := range includeCols {
 			if indexCol == includeCol {
 				include = true

--- a/common/key_encoding.go
+++ b/common/key_encoding.go
@@ -169,17 +169,25 @@ func EncodeKeyCol(row *Row, colIndex int, colType ColumnType, buffer []byte) ([]
 	return buffer, nil
 }
 
-func DecodeIndexKeyWithIgnoredCols(buffer []byte, offset int, colTypes []ColumnType, includeCols []int, indexCols []int, startCol int, rows *Rows) (int, error) {
+func DecodeIndexKeyWithIgnoredCols(buffer []byte, offset int, colTypes []ColumnType, includeCols []int, indexCols []int, rows *Rows) (int, error) {
 	var err error
+	rowColIndex := 0
 	for _, indexCol := range indexCols {
 		colType := colTypes[indexCol]
-		include := includeCols == nil || Contains(includeCols, indexCol)
-		offset, err = DecodeIndexKeyCol(buffer, offset, colType, include, startCol, false, rows)
+		include := false
+		//include := includeCols == nil || Contains(includeCols, indexCol)
+		for i, includeCol := range includeCols {
+			if indexCol == includeCol {
+				include = true
+				rowColIndex = i
+			}
+		}
+		offset, err = DecodeIndexKeyCol(buffer, offset, colType, include, rowColIndex, false, rows)
 		if err != nil {
 			return 0, errors.WithStack(err)
 		}
 		if include {
-			startCol++
+			rowColIndex++
 		}
 	}
 	return offset, nil

--- a/common/row_encoding.go
+++ b/common/row_encoding.go
@@ -62,63 +62,72 @@ func DecodeRow(buffer []byte, colTypes []ColumnType, rows *Rows) error {
 func DecodeRowWithIgnoredCols(buffer []byte, colTypes []ColumnType, includeCol []bool, rows *Rows) error {
 	offset := 0
 	colIndex := 0
+	var err error
 	for i, colType := range colTypes {
 		include := includeCol == nil || includeCol[i]
-		if buffer[offset] == 0 {
-			offset++
-			if include {
-				rows.AppendNullToColumn(colIndex)
-			}
-		} else {
-			offset++
-			switch colType.Type {
-			case TypeTinyInt, TypeInt, TypeBigInt:
-				var u uint64
-				u, offset = ReadUint64FromBufferLE(buffer, offset)
-				if include {
-					rows.AppendInt64ToColumn(colIndex, int64(u))
-				}
-			case TypeDecimal:
-				var val Decimal
-				var err error
-				val, offset, err = ReadDecimalFromBuffer(buffer, offset, colType.DecPrecision, colType.DecScale)
-				if err != nil {
-					return errors.WithStack(err)
-				}
-				if include {
-					rows.AppendDecimalToColumn(colIndex, val)
-				}
-			case TypeDouble:
-				var val float64
-				val, offset = ReadFloat64FromBufferLE(buffer, offset)
-				if include {
-					rows.AppendFloat64ToColumn(colIndex, val)
-				}
-			case TypeVarchar:
-				var val string
-				val, offset = ReadStringFromBufferLE(buffer, offset)
-				if include {
-					rows.AppendStringToColumn(colIndex, val)
-				}
-			case TypeTimestamp:
-				var (
-					val Timestamp
-					err error
-				)
-				val, offset, err = ReadTimestampFromBuffer(buffer, offset, colType.FSP)
-				if err != nil {
-					return errors.WithStack(err)
-				}
-				if include {
-					rows.AppendTimestampToColumn(colIndex, val)
-				}
-			default:
-				return errors.Errorf("unexpected column type %d", colType)
-			}
+		offset, err = DecodeRowCol(buffer, offset, rows, colType, colIndex, include)
+		if err != nil {
+			return errors.WithStack(err)
 		}
 		if include {
 			colIndex++
 		}
 	}
 	return nil
+}
+
+func DecodeRowCol(buffer []byte, offset int, rows *Rows, colType ColumnType, colIndex int, include bool) (int, error) {
+	if buffer[offset] == 0 {
+		offset++
+		if include {
+			rows.AppendNullToColumn(colIndex)
+		}
+	} else {
+		offset++
+		switch colType.Type {
+		case TypeTinyInt, TypeInt, TypeBigInt:
+			var u uint64
+			u, offset = ReadUint64FromBufferLE(buffer, offset)
+			if include {
+				rows.AppendInt64ToColumn(colIndex, int64(u))
+			}
+		case TypeDecimal:
+			var val Decimal
+			var err error
+			val, offset, err = ReadDecimalFromBuffer(buffer, offset, colType.DecPrecision, colType.DecScale)
+			if err != nil {
+				return 0, errors.WithStack(err)
+			}
+			if include {
+				rows.AppendDecimalToColumn(colIndex, val)
+			}
+		case TypeDouble:
+			var val float64
+			val, offset = ReadFloat64FromBufferLE(buffer, offset)
+			if include {
+				rows.AppendFloat64ToColumn(colIndex, val)
+			}
+		case TypeVarchar:
+			var val string
+			val, offset = ReadStringFromBufferLE(buffer, offset)
+			if include {
+				rows.AppendStringToColumn(colIndex, val)
+			}
+		case TypeTimestamp:
+			var (
+				val Timestamp
+				err error
+			)
+			val, offset, err = ReadTimestampFromBuffer(buffer, offset, colType.FSP)
+			if err != nil {
+				return 0, errors.WithStack(err)
+			}
+			if include {
+				rows.AppendTimestampToColumn(colIndex, val)
+			}
+		default:
+			return 0, errors.Errorf("unexpected column type %d", colType)
+		}
+	}
+	return offset, nil
 }

--- a/parplan/logical_plan_test.go
+++ b/parplan/logical_plan_test.go
@@ -224,7 +224,7 @@ func attachIndexToSchema(schema *common.Schema) (*common.Schema, error) {
 		SchemaName: "test",
 		Name:       "index1",
 		TableName:  "table1",
-		IndexCols:  []int{1},
+		IndexCols:  []int{2},
 	}
 	if err := schema.PutIndex(index1); err != nil {
 		return nil, errors.WithStack(err)

--- a/parplan/logical_plan_test.go
+++ b/parplan/logical_plan_test.go
@@ -226,8 +226,7 @@ func attachIndexToSchema(schema *common.Schema) (*common.Schema, error) {
 		TableName:  "table1",
 		IndexCols:  []int{1},
 	}
-	err := schema.PutIndex(index1)
-	if err != nil {
+	if err := schema.PutIndex(index1); err != nil {
 		return nil, errors.WithStack(err)
 	}
 	return schema, nil

--- a/parplan/logical_plan_test.go
+++ b/parplan/logical_plan_test.go
@@ -18,9 +18,11 @@
 package parplan
 
 import (
-	"github.com/squareup/pranadb/common"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSimpleWildcard(t *testing.T) {
@@ -214,4 +216,19 @@ func createTestSchema() *common.Schema {
 	}
 	schema.PutTable(table2.Name, table2)
 	return schema
+}
+
+func attachIndexToSchema(schema *common.Schema) (*common.Schema, error) {
+	index1 := &common.IndexInfo{
+		ID:         0,
+		SchemaName: "test",
+		Name:       "index1",
+		TableName:  "table1",
+		IndexCols:  []int{1},
+	}
+	err := schema.PutIndex(index1)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return schema, nil
 }

--- a/parplan/physical_plan_test.go
+++ b/parplan/physical_plan_test.go
@@ -54,11 +54,24 @@ func TestPointGetUsesIndexScanForPullQuery(t *testing.T) {
 	schema, err := attachIndexToSchema(schema)
 	require.NoError(t, err)
 	planner := NewPlanner(schema)
-	physi, _, err := planner.QueryToPlan("select col1 from table1 where col1='abc'", false, true)
+	physi, _, err := planner.QueryToPlan("select col2 from table1 where col2=1", false, true)
 	require.NoError(t, err)
 	is, ok := physi.(*planner2.PhysicalIndexScan)
 	require.True(t, ok)
 	require.Equal(t, 0, len(is.Children()))
 	require.Equal(t, 1, len(is.Ranges))
 	require.True(t, is.Ranges[0].IsPoint(planner.StatementContext()))
+}
+
+func TestRangeUsesIndexScanForPullQuery(t *testing.T) {
+	schema := createTestSchema()
+	schema, err := attachIndexToSchema(schema)
+	require.NoError(t, err)
+	planner := NewPlanner(schema)
+	physi, _, err := planner.QueryToPlan("select col2 from table1 where col2 > 1", false, true)
+	require.NoError(t, err)
+	is, ok := physi.(*planner2.PhysicalIndexScan)
+	require.True(t, ok)
+	require.Equal(t, 0, len(is.Children()))
+	require.Equal(t, 1, len(is.Ranges))
 }

--- a/parplan/physical_plan_test.go
+++ b/parplan/physical_plan_test.go
@@ -52,6 +52,7 @@ func TestPointGetUsesSelectForPushQuery(t *testing.T) {
 func TestPointGetUsesIndexScanForPullQuery(t *testing.T) {
 	schema := createTestSchema()
 	schema, err := attachIndexToSchema(schema)
+	require.NoError(t, err)
 	planner := NewPlanner(schema)
 	physi, _, err := planner.QueryToPlan("select col1 from table1 where col1='abc'", false, true)
 	require.NoError(t, err)

--- a/pull/exec/index_reader.go
+++ b/pull/exec/index_reader.go
@@ -21,10 +21,6 @@ type PullIndexReader struct {
 
 var _ PullExecutor = &PullIndexReader{}
 
-/*
-No hidden cols
-*/
-
 func NewPullIndexReader(tableInfo *common.TableInfo,
 	indexInfo *common.IndexInfo,
 	includedCols []int, // Col indexes in the table that are being returned

--- a/pull/exec/index_reader.go
+++ b/pull/exec/index_reader.go
@@ -122,6 +122,7 @@ func NewPullIndexReader(tableInfo *common.TableInfo,
 	}, nil
 }
 
+//nolint:gocyclo
 func (p *PullIndexReader) GetRows(limit int) (rows *common.Rows, err error) {
 	if limit < 1 {
 		return nil, errors.Errorf("invalid limit %d", limit)

--- a/pull/exec/index_reader.go
+++ b/pull/exec/index_reader.go
@@ -171,11 +171,17 @@ func (p *PullIndexReader) GetRows(limit int) (rows *common.Rows, err error) { //
 		// Index covers if all cols are in the index
 		if len(nonIndexCols) == 0 {
 			offset := 16
-			offset, err := common.DecodeIndexKeyWithIgnoredCols(kvPair.Key, offset, p.tableInfo.ColumnTypes, p.includeCols, p.indexInfo.IndexCols, len(includedPkCols), rows)
+			offset, err := common.DecodeIndexKeyWithIgnoredCols(kvPair.Key, offset, p.tableInfo.ColumnTypes, p.includeCols, p.indexInfo.IndexCols, rows)
 
 			for _, pkCol := range includedPkCols {
 				colType := p.tableInfo.ColumnTypes[pkCol]
-				_, err = common.DecodeIndexKeyCol(kvPair.Key, offset, colType, true, pkCol, true, rows)
+				var rowColIndex int
+				for j, col := range p.includeCols {
+					if col == pkCol {
+						rowColIndex = j
+					}
+				}
+				_, err = common.DecodeIndexKeyCol(kvPair.Key, offset, colType, true, rowColIndex, true, rows)
 			}
 			if err != nil {
 				return nil, errors.WithStack(err)

--- a/pull/exec/index_reader.go
+++ b/pull/exec/index_reader.go
@@ -122,8 +122,7 @@ func NewPullIndexReader(tableInfo *common.TableInfo,
 	}, nil
 }
 
-//nolint:gocyclo
-func (p *PullIndexReader) GetRows(limit int) (rows *common.Rows, err error) {
+func (p *PullIndexReader) GetRows(limit int) (rows *common.Rows, err error) { //nolint:gocyclo
 	if limit < 1 {
 		return nil, errors.Errorf("invalid limit %d", limit)
 	}

--- a/pull/exec/index_reader.go
+++ b/pull/exec/index_reader.go
@@ -86,10 +86,6 @@ func NewPullIndexReader(tableInfo *common.TableInfo,
 				if err != nil {
 					return nil, err
 				}
-
-				if err != nil {
-					return nil, err
-				}
 			}
 			if !scanRange.HighExcl {
 				if !allBitsSet(rangeEnd) {

--- a/pull/exec/table_scan.go
+++ b/pull/exec/table_scan.go
@@ -72,7 +72,7 @@ func NewPullTableScan(tableInfo *common.TableInfo, colIndexes []int, storage clu
 			return nil, errors.WithStack(err)
 		}
 		if !scanRange.HighExcl {
-			if !allBitsSet(rangeEnd) {
+			if !allBitsSet(rangeEnd[16:]) {
 				rangeEnd = common.IncrementBytesBigEndian(rangeEnd)
 			} else {
 				rangeEnd = nil

--- a/pull/exec_builder.go
+++ b/pull/exec_builder.go
@@ -101,7 +101,7 @@ func (p *Engine) buildPullDAG(session *sess.Session, plan planner.PhysicalPlan, 
 		if remote {
 			tableName := op.Table.Name.L
 			indexName := op.Index.Name.L
-			executor, err = p.createPullIndexScan(session.Schema, tableName, indexName, op.Ranges, op.Columns, session.QueryInfo.ShardID, op.Covers)
+			executor, err = p.createPullIndexScan(session.Schema, tableName, indexName, op.Ranges, op.Columns, session.QueryInfo.ShardID)
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
@@ -201,7 +201,7 @@ func (p *Engine) createPullTableScan(schema *common.Schema, tableName string, ra
 	return exec.NewPullTableScan(tbl.GetTableInfo(), colIndexes, p.cluster, shardID, scanRange)
 }
 
-func (p *Engine) createPullIndexScan(schema *common.Schema, tableName string, indexName string, ranges []*ranger.Range, columns []*model.ColumnInfo, shardID uint64, covers bool) (exec.PullExecutor, error) {
+func (p *Engine) createPullIndexScan(schema *common.Schema, tableName string, indexName string, ranges []*ranger.Range, columns []*model.ColumnInfo, shardID uint64) (exec.PullExecutor, error) {
 	tbl, ok := schema.GetTable(tableName)
 	if !ok {
 		return nil, errors.Errorf("unknown source or materialized view %s", tableName)
@@ -230,7 +230,7 @@ func (p *Engine) createPullIndexScan(schema *common.Schema, tableName string, in
 	for _, col := range columns {
 		colIndexes = append(colIndexes, col.Offset)
 	}
-	return exec.NewPullIndexReader(tbl.GetTableInfo(), idx, colIndexes, p.cluster, shardID, scanRanges, covers)
+	return exec.NewPullIndexReader(tbl.GetTableInfo(), idx, colIndexes, p.cluster, shardID, scanRanges)
 }
 
 func (p *Engine) byItemsToDescAndSortExpression(byItems []*util.ByItems) ([]bool, []*common.Expression) {

--- a/pull/exec_builder.go
+++ b/pull/exec_builder.go
@@ -3,6 +3,8 @@ package pull
 import (
 	"strings"
 
+	"github.com/squareup/pranadb/tidb/expression"
+
 	"github.com/pingcap/parser/model"
 	"github.com/squareup/pranadb/common"
 	"github.com/squareup/pranadb/errors"
@@ -101,7 +103,7 @@ func (p *Engine) buildPullDAG(session *sess.Session, plan planner.PhysicalPlan, 
 		if remote {
 			tableName := op.Table.Name.L
 			indexName := op.Index.Name.L
-			executor, err = p.createPullIndexScan(session.Schema, tableName, indexName, op.Ranges, op.Columns, session.QueryInfo.ShardID)
+			executor, err = p.createPullIndexScan(session.Schema, tableName, indexName, op.Ranges, op.Schema().Columns, op.Columns, session.QueryInfo.ShardID)
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
@@ -201,7 +203,7 @@ func (p *Engine) createPullTableScan(schema *common.Schema, tableName string, ra
 	return exec.NewPullTableScan(tbl.GetTableInfo(), colIndexes, p.cluster, shardID, scanRange)
 }
 
-func (p *Engine) createPullIndexScan(schema *common.Schema, tableName string, indexName string, ranges []*ranger.Range, columns []*model.ColumnInfo, shardID uint64) (exec.PullExecutor, error) {
+func (p *Engine) createPullIndexScan(schema *common.Schema, tableName string, indexName string, ranges []*ranger.Range, planSchemaColumns []*expression.Column, columnInfos []*model.ColumnInfo, shardID uint64) (exec.PullExecutor, error) {
 	tbl, ok := schema.GetTable(tableName)
 	if !ok {
 		return nil, errors.Errorf("unknown source or materialized view %s", tableName)
@@ -227,8 +229,13 @@ func (p *Engine) createPullIndexScan(schema *common.Schema, tableName string, in
 		}
 	}
 	var colIndexes []int
-	for _, col := range columns {
-		colIndexes = append(colIndexes, col.Offset)
+	for _, col := range planSchemaColumns {
+		for _, colInfo := range columnInfos {
+			if col.ID == colInfo.ID {
+				colIndexes = append(colIndexes, colInfo.Offset)
+				break
+			}
+		}
 	}
 	return exec.NewPullIndexReader(tbl.GetTableInfo(), idx, colIndexes, p.cluster, shardID, scanRanges)
 }

--- a/pull/exec_builder.go
+++ b/pull/exec_builder.go
@@ -110,7 +110,7 @@ func (p *Engine) buildPullDAG(session *sess.Session, plan planner.PhysicalPlan, 
 			if err != nil {
 				return nil, err
 			}
-			executor = exec.NewRemoteExecutor(remoteDag, session.QueryInfo, colNames, colTypes, session.Schema.Name, p.cluster,
+			executor = exec.NewRemoteExecutor(remoteDag, session.QueryInfo, remoteDag.ColNames(), remoteDag.ColTypes(), session.Schema.Name, p.cluster,
 				-1)
 		}
 	case *planner.PhysicalSort:

--- a/push/exec/index_exec.go
+++ b/push/exec/index_exec.go
@@ -59,5 +59,9 @@ func (t *IndexExecutor) createKeyBuff(shardID uint64, row *common.Row) ([]byte, 
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	keyBuff, err = common.EncodeKeyCols(row, t.TableInfo.PrimaryKeyCols, t.TableInfo.ColumnTypes, keyBuff)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
 	return keyBuff, nil
 }

--- a/sqltest/testdata/planner_index_test_out.txt
+++ b/sqltest/testdata/planner_index_test_out.txt
@@ -51,18 +51,18 @@ select customer_id from transactions where customer_id = 1000000;
 
 --test partially-covering index;
 
-select * from transactions where customer_id = 600;
-|customer_id|id|col2|
-|7|600|abc|
+select * from transactions where customer_id = 600 order by id;
+|id|customer_id|col2|
 |6|600|abc|
+|7|600|abc|
 2 rows returned
 
-select * from transactions where id > 5;
+select * from transactions where id > 5 order by id;
 |id|customer_id|col2|
-|7|600|abc|
-|9|900|abc|
-|8|800|abc|
 |6|600|abc|
+|7|600|abc|
+|8|800|abc|
+|9|900|abc|
 |10|1000|abc|
 5 rows returned
 
@@ -74,14 +74,14 @@ drop index index1 on transactions;
 create index index2 on transactions (customer_id, col2);
 0 rows returned
 
-select * from transactions where id > 10;
+select * from transactions where id > 10 order by id;
 |id|customer_id|col2|
 0 rows returned
 
-select * from transactions where customer_id = 600;
-|customer_id|col2|id|
-|600|abc|7|
-|600|abc|6|
+select * from transactions where customer_id = 600 order by id;
+|id|customer_id|col2|
+|6|600|abc|
+|7|600|abc|
 2 rows returned
 
 select col2 from transactions where col2 = 'abc';
@@ -95,7 +95,7 @@ select col2 from transactions where col2 = 'abc';
 |abc|
 7 rows returned
 
-select col2, customer_id from transactions where customer_id = 600;
+select col2, customer_id from transactions where customer_id = 600 order by customer_id, col2;
 |col2|customer_id|
 |abc|600|
 |abc|600|
@@ -108,17 +108,17 @@ select customer_id from transactions where customer_id > 600;
 |1000|
 3 rows returned
 
-select * from transactions where customer_id > 600 and customer_id < 900;
-|customer_id|col2|id|
-|800|abc|8|
+select * from transactions where customer_id > 600 and customer_id < 900 order by id;
+|id|customer_id|col2|
+|8|800|abc|
 1 rows returned
 
-select * from transactions where customer_id > 300 and col2 is null;
-|customer_id|col2|id|
-|400|null|4|
+select * from transactions where customer_id > 300 and col2 is null order by id;
+|id|customer_id|col2|
+|4|400|null|
 1 rows returned
 
-select customer_id, id, col2 from transactions where customer_id > 300 and col2 is null;
+select customer_id, id, col2 from transactions where customer_id > 300 and col2 is null order by customer_id, id, col2;
 |customer_id|id|col2|
 |400|4|null|
 1 rows returned

--- a/sqltest/testdata/planner_index_test_out.txt
+++ b/sqltest/testdata/planner_index_test_out.txt
@@ -33,10 +33,10 @@ select customer_id from transactions where customer_id = 600;
 |600|
 2 rows returned
 
-select customer_id from transactions where customer_id > 600;
+select customer_id from transactions where customer_id > 600 order by customer_id;
 |customer_id|
-|900|
 |800|
+|900|
 |1000|
 3 rows returned
 
@@ -95,16 +95,16 @@ select col2 from transactions where col2 = 'abc';
 |abc|
 7 rows returned
 
-select col2, customer_id from transactions where customer_id = 600 order by customer_id, col2;
+select col2, customer_id from transactions where customer_id = 600 order by col2;
 |col2|customer_id|
 |abc|600|
 |abc|600|
 2 rows returned
 
-select customer_id from transactions where customer_id > 600;
+select customer_id from transactions where customer_id > 600 order by customer_id;
 |customer_id|
-|900|
 |800|
+|900|
 |1000|
 3 rows returned
 
@@ -118,7 +118,7 @@ select * from transactions where customer_id > 300 and col2 is null order by id;
 |4|400|null|
 1 rows returned
 
-select customer_id, id, col2 from transactions where customer_id > 300 and col2 is null order by customer_id, id, col2;
+select customer_id, id, col2 from transactions where customer_id > 300 and col2 is null order by customer_id, id;
 |customer_id|id|col2|
 |400|4|null|
 1 rows returned

--- a/sqltest/testdata/planner_index_test_out.txt
+++ b/sqltest/testdata/planner_index_test_out.txt
@@ -33,6 +33,13 @@ select customer_id from transactions where customer_id = 600;
 |600|
 2 rows returned
 
+select customer_id from transactions where customer_id > 600;
+|customer_id|
+|900|
+|800|
+|1000|
+3 rows returned
+
 select customer_id from transactions where customer_id is null;
 |customer_id|
 |null|
@@ -45,10 +52,19 @@ select customer_id from transactions where customer_id = 1000000;
 --test partially-covering index;
 
 select * from transactions where customer_id = 600;
-|id|customer_id|col2|
+|customer_id|id|col2|
 |7|600|abc|
 |6|600|abc|
 2 rows returned
+
+select * from transactions where id > 5;
+|id|customer_id|col2|
+|7|600|abc|
+|9|900|abc|
+|8|800|abc|
+|6|600|abc|
+|10|1000|abc|
+5 rows returned
 
 drop index index1 on transactions;
 0 rows returned
@@ -58,10 +74,14 @@ drop index index1 on transactions;
 create index index2 on transactions (customer_id, col2);
 0 rows returned
 
-select * from transactions where customer_id = 600;
+select * from transactions where id > 10;
 |id|customer_id|col2|
-|7|600|abc|
-|6|600|abc|
+0 rows returned
+
+select * from transactions where customer_id = 600;
+|customer_id|col2|id|
+|600|abc|7|
+|600|abc|6|
 2 rows returned
 
 select col2 from transactions where col2 = 'abc';
@@ -80,6 +100,28 @@ select col2, customer_id from transactions where customer_id = 600;
 |abc|600|
 |abc|600|
 2 rows returned
+
+select customer_id from transactions where customer_id > 600;
+|customer_id|
+|900|
+|800|
+|1000|
+3 rows returned
+
+select * from transactions where customer_id > 600 and customer_id < 900;
+|customer_id|col2|id|
+|800|abc|8|
+1 rows returned
+
+select * from transactions where customer_id > 300 and col2 is null;
+|customer_id|col2|id|
+|400|null|4|
+1 rows returned
+
+select customer_id, id, col2 from transactions where customer_id > 300 and col2 is null;
+|customer_id|id|col2|
+|400|4|null|
+1 rows returned
 
 drop index index2 on transactions;
 0 rows returned

--- a/sqltest/testdata/planner_index_test_out.txt
+++ b/sqltest/testdata/planner_index_test_out.txt
@@ -33,6 +33,14 @@ select customer_id from transactions where customer_id = 600;
 |600|
 2 rows returned
 
+--test with partially-covering index;
+
+select customer_id, col2 from transactions where customer_id = 600;
+|customer_id|col2|
+|600|abc|
+|600|abc|
+2 rows returned
+
 select customer_id from transactions where customer_id is null;
 |customer_id|
 |null|

--- a/sqltest/testdata/planner_index_test_out.txt
+++ b/sqltest/testdata/planner_index_test_out.txt
@@ -33,14 +33,6 @@ select customer_id from transactions where customer_id = 600;
 |600|
 2 rows returned
 
---test with partially-covering index;
-
-select customer_id, col2 from transactions where customer_id = 600;
-|customer_id|col2|
-|600|abc|
-|600|abc|
-2 rows returned
-
 select customer_id from transactions where customer_id is null;
 |customer_id|
 |null|
@@ -50,7 +42,46 @@ select customer_id from transactions where customer_id = 1000000;
 |customer_id|
 0 rows returned
 
+--test partially-covering index;
+
+select * from transactions where customer_id = 600;
+|id|customer_id|col2|
+|7|600|abc|
+|6|600|abc|
+2 rows returned
+
 drop index index1 on transactions;
+0 rows returned
+
+--test multi-col index;
+
+create index index2 on transactions (customer_id, col2);
+0 rows returned
+
+select * from transactions where customer_id = 600;
+|id|customer_id|col2|
+|7|600|abc|
+|6|600|abc|
+2 rows returned
+
+select col2 from transactions where col2 = 'abc';
+|col2|
+|abc|
+|abc|
+|abc|
+|abc|
+|abc|
+|abc|
+|abc|
+7 rows returned
+
+select col2, customer_id from transactions where customer_id = 600;
+|col2|customer_id|
+|abc|600|
+|abc|600|
+2 rows returned
+
+drop index index2 on transactions;
 0 rows returned
 
 drop source transactions;

--- a/sqltest/testdata/planner_index_test_script.txt
+++ b/sqltest/testdata/planner_index_test_script.txt
@@ -26,15 +26,27 @@ create index index1 on transactions (customer_id);
 
 select customer_id from transactions where customer_id = 600;
 
---test with partially-covering index;
-
-select customer_id, col2 from transactions where customer_id = 600;
-
 select customer_id from transactions where customer_id is null;
 
 select customer_id from transactions where customer_id = 1000000;
 
+--test partially-covering index;
+
+select * from transactions where customer_id = 600;
+
 drop index index1 on transactions;
+
+--test multi-col index;
+
+create index index2 on transactions (customer_id, col2);
+
+select * from transactions where customer_id = 600;
+
+select col2 from transactions where col2 = 'abc';
+
+select col2, customer_id from transactions where customer_id = 600;
+
+drop index index2 on transactions;
 
 drop source transactions;
 

--- a/sqltest/testdata/planner_index_test_script.txt
+++ b/sqltest/testdata/planner_index_test_script.txt
@@ -26,7 +26,7 @@ create index index1 on transactions (customer_id);
 
 select customer_id from transactions where customer_id = 600;
 
-select customer_id from transactions where customer_id > 600;
+select customer_id from transactions where customer_id > 600 order by customer_id;
 
 select customer_id from transactions where customer_id is null;
 
@@ -50,15 +50,15 @@ select * from transactions where customer_id = 600 order by id;
 
 select col2 from transactions where col2 = 'abc';
 
-select col2, customer_id from transactions where customer_id = 600 order by customer_id, col2;
+select col2, customer_id from transactions where customer_id = 600 order by col2;
 
-select customer_id from transactions where customer_id > 600;
+select customer_id from transactions where customer_id > 600 order by customer_id;
 
 select * from transactions where customer_id > 600 and customer_id < 900 order by id;
 
 select * from transactions where customer_id > 300 and col2 is null order by id;
 
-select customer_id, id, col2 from transactions where customer_id > 300 and col2 is null order by customer_id, id, col2;
+select customer_id, id, col2 from transactions where customer_id > 300 and col2 is null order by customer_id, id;
 
 drop index index2 on transactions;
 

--- a/sqltest/testdata/planner_index_test_script.txt
+++ b/sqltest/testdata/planner_index_test_script.txt
@@ -36,17 +36,29 @@ select customer_id from transactions where customer_id = 1000000;
 
 select * from transactions where customer_id = 600;
 
+select * from transactions where id > 5;
+
 drop index index1 on transactions;
 
 --test multi-col index;
 
 create index index2 on transactions (customer_id, col2);
 
+select * from transactions where id > 10;
+
 select * from transactions where customer_id = 600;
 
 select col2 from transactions where col2 = 'abc';
 
 select col2, customer_id from transactions where customer_id = 600;
+
+select customer_id from transactions where customer_id > 600;
+
+select * from transactions where customer_id > 600 and customer_id < 900;
+
+select * from transactions where customer_id > 300 and col2 is null;
+
+select customer_id, col2, id from transactions where customer_id > 300 and col2 is null;
 
 drop index index2 on transactions;
 

--- a/sqltest/testdata/planner_index_test_script.txt
+++ b/sqltest/testdata/planner_index_test_script.txt
@@ -34,9 +34,9 @@ select customer_id from transactions where customer_id = 1000000;
 
 --test partially-covering index;
 
-select * from transactions where customer_id = 600;
+select * from transactions where customer_id = 600 order by id;
 
-select * from transactions where id > 5;
+select * from transactions where id > 5 order by id;
 
 drop index index1 on transactions;
 
@@ -44,21 +44,21 @@ drop index index1 on transactions;
 
 create index index2 on transactions (customer_id, col2);
 
-select * from transactions where id > 10;
+select * from transactions where id > 10 order by id;
 
-select * from transactions where customer_id = 600;
+select * from transactions where customer_id = 600 order by id;
 
 select col2 from transactions where col2 = 'abc';
 
-select col2, customer_id from transactions where customer_id = 600;
+select col2, customer_id from transactions where customer_id = 600 order by customer_id, col2;
 
 select customer_id from transactions where customer_id > 600;
 
-select * from transactions where customer_id > 600 and customer_id < 900;
+select * from transactions where customer_id > 600 and customer_id < 900 order by id;
 
-select * from transactions where customer_id > 300 and col2 is null;
+select * from transactions where customer_id > 300 and col2 is null order by id;
 
-select customer_id, id, col2 from transactions where customer_id > 300 and col2 is null;
+select customer_id, id, col2 from transactions where customer_id > 300 and col2 is null order by customer_id, id, col2;
 
 drop index index2 on transactions;
 

--- a/sqltest/testdata/planner_index_test_script.txt
+++ b/sqltest/testdata/planner_index_test_script.txt
@@ -26,6 +26,8 @@ create index index1 on transactions (customer_id);
 
 select customer_id from transactions where customer_id = 600;
 
+select customer_id from transactions where customer_id > 600;
+
 select customer_id from transactions where customer_id is null;
 
 select customer_id from transactions where customer_id = 1000000;

--- a/sqltest/testdata/planner_index_test_script.txt
+++ b/sqltest/testdata/planner_index_test_script.txt
@@ -26,6 +26,10 @@ create index index1 on transactions (customer_id);
 
 select customer_id from transactions where customer_id = 600;
 
+--test with partially-covering index;
+
+select customer_id, col2 from transactions where customer_id = 600;
+
 select customer_id from transactions where customer_id is null;
 
 select customer_id from transactions where customer_id = 1000000;

--- a/sqltest/testdata/planner_index_test_script.txt
+++ b/sqltest/testdata/planner_index_test_script.txt
@@ -58,7 +58,7 @@ select * from transactions where customer_id > 600 and customer_id < 900;
 
 select * from transactions where customer_id > 300 and col2 is null;
 
-select customer_id, col2, id from transactions where customer_id > 300 and col2 is null;
+select customer_id, id, col2 from transactions where customer_id > 300 and col2 is null;
 
 drop index index2 on transactions;
 

--- a/tidb/planner/logical_datasource.go
+++ b/tidb/planner/logical_datasource.go
@@ -140,6 +140,8 @@ func (ds *LogicalDataSource) Convert2Scans() (scans []LogicalPlan) {
 			// If index columns can cover all of the needed columns, we can use a IndexGather + IndexScan.
 			if ds.isCoveringIndex(ds.schema.Columns, path.FullIdxCols, path.FullIdxColLens, ds.tableInfo) {
 				scans = append(scans, ds.buildIndexScan(path, false))
+			} else if ds.isPartiallyCoveringIndex(ds.schema.Columns, path.FullIdxCols, ds.tableInfo) {
+				scans = append(scans, ds.buildIndexScan(path, true))
 			}
 		}
 	}
@@ -469,7 +471,7 @@ func (ds *LogicalDataSource) isCoveringIndex(columns, indexColumns []*expression
 	return true
 }
 
-func (ds *LogicalDataSource) isPartiallyCoveringIndex(columns, indexColumns []*expression.Column, idxColLens []int, tblInfo *model.TableInfo) bool {
+func (ds *LogicalDataSource) isPartiallyCoveringIndex(columns, indexColumns []*expression.Column, tblInfo *model.TableInfo) bool {
 	for _, col := range columns {
 		if tblInfo.PKIsHandle && mysql.HasPriKeyFlag(col.RetType.Flag) {
 			continue

--- a/tidb/planner/logical_indexscan.go
+++ b/tidb/planner/logical_indexscan.go
@@ -19,6 +19,8 @@ package planner
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/squareup/pranadb/tidb/expression"
@@ -26,7 +28,6 @@ import (
 	"github.com/squareup/pranadb/tidb/sessionctx"
 	"github.com/squareup/pranadb/tidb/types"
 	"github.com/squareup/pranadb/tidb/util/ranger"
-	"strings"
 )
 
 // LogicalIndexScan is the logical index scan operator for TiKV.

--- a/tidb/planner/physical_indexscan.go
+++ b/tidb/planner/physical_indexscan.go
@@ -20,11 +20,9 @@ package planner
 
 import (
 	"github.com/pingcap/parser/model"
-	"github.com/pingcap/parser/mysql"
 	"github.com/squareup/pranadb/tidb/expression"
 	"github.com/squareup/pranadb/tidb/sessionctx"
 	"github.com/squareup/pranadb/tidb/statistics"
-	"github.com/squareup/pranadb/tidb/types"
 	"github.com/squareup/pranadb/tidb/util/ranger"
 )
 
@@ -74,91 +72,6 @@ func (p PhysicalIndexScan) Init(ctx sessionctx.Context, offset int) *PhysicalInd
 //   PhysicalIndexScan.IdxCols       []*expression.Column
 //   PhysicalIndexScan.Columns       []*model.ColumnInfo
 func (is *PhysicalIndexScan) initSchema(idxExprCols []*expression.Column, isDoubleRead bool) {
-	indexCols := make([]*expression.Column, len(is.IdxCols), len(is.Index.Columns)+1)
-	copy(indexCols, is.IdxCols)
-
-	for i := len(is.IdxCols); i < len(is.Index.Columns); i++ {
-		if idxExprCols[i] != nil {
-			indexCols = append(indexCols, idxExprCols[i])
-		} else {
-			// TODO: try to reuse the col generated when building the LogicalDataSource.
-			colInfo := is.Table.Columns[is.Index.Columns[i].Offset]
-			fieldName := &types.FieldName{
-				DBName:            is.DBName,
-				TblName:           is.Table.Name,
-				ColName:           colInfo.Name,
-				OrigTblName:       is.Table.Name,
-				OrigColName:       colInfo.Name,
-				Hidden:            colInfo.Hidden,
-				NotExplicitUsable: colInfo.State != model.StatePublic,
-			}
-			indexCols = append(indexCols, &expression.Column{
-				ID:       colInfo.ID,
-				RetType:  &colInfo.FieldType,
-				UniqueID: is.ctx.GetSessionVars().AllocPlanColumnID(),
-				OrigName: fieldName.String(),
-			})
-		}
-	}
-	is.NeedCommonHandle = is.Table.IsCommonHandle
-
-	if is.NeedCommonHandle {
-		for i := len(is.Index.Columns); i < len(idxExprCols); i++ {
-			indexCols = append(indexCols, idxExprCols[i])
-		}
-	}
-	//setHandle := false
-	// TODO - for some reason was adding the PK col again (resulting in same col twice) when the index was on the PK
-	// Commenting out seems to fix - need to investigate more
-	//setHandle := len(indexCols) > len(is.Index.Columns)
-	//if !setHandle {
-	//	for i, col := range is.Columns {
-	//		if (mysql.HasPriKeyFlag(col.Flag) && is.Table.PKIsHandle) || col.ID == model.ExtraHandleID {
-	//			indexCols = append(indexCols, is.dataSourceSchema.Columns[i])
-	//			setHandle = true
-	//			break
-	//		}
-	//	}
-	//}
-
-	if isDoubleRead {
-		// If it's a double read, we need to add the queried columns that are not already in the index.
-		for _, queryCol := range is.Columns {
-			setQueryCol := true
-			for _, idxCol := range is.IdxCols {
-				if queryCol.ID == idxCol.ID {
-					setQueryCol = false
-				}
-			}
-			if setQueryCol {
-				indexCols = append(indexCols, &expression.Column{
-					RetType:  types.NewFieldType(queryCol.FieldType.Tp),
-					ID:       queryCol.ID,
-					UniqueID: queryCol.ID,
-					OrigName: is.DBName.L + "." + is.Table.Name.L + "." + queryCol.Name.L,
-				})
-			}
-		}
-		// If it's double read case, the first index must return handle. So we should add extra handle column
-		// if there isn't a handle column.
-		//if !setHandle {
-		//	if !is.Table.IsCommonHandle {
-		//		indexCols = append(indexCols, &expression.Column{
-		//			RetType:  types.NewFieldType(mysql.TypeLonglong),
-		//			ID:       model.ExtraHandleID,
-		//			UniqueID: is.ctx.GetSessionVars().AllocPlanColumnID(),
-		//		})
-		//	}
-		//}
-		// If index is global, we should add extra column for pid.
-		if is.Index.Global {
-			indexCols = append(indexCols, &expression.Column{
-				RetType:  types.NewFieldType(mysql.TypeLonglong),
-				ID:       model.ExtraPidColID,
-				UniqueID: is.ctx.GetSessionVars().AllocPlanColumnID(),
-			})
-		}
-	}
-
-	is.SetSchema(expression.NewSchema(indexCols...))
+	// Should always be the same as logical schema
+	is.SetSchema(is.dataSourceSchema)
 }

--- a/tidb/planner/physical_indexscan.go
+++ b/tidb/planner/physical_indexscan.go
@@ -84,10 +84,21 @@ func (is *PhysicalIndexScan) initSchema(idxExprCols []*expression.Column, isDoub
 			indexCols = append(indexCols, idxExprCols[i])
 		} else {
 			// TODO: try to reuse the col generated when building the LogicalDataSource.
+			colInfo := is.Table.Columns[is.Index.Columns[i].Offset]
+			fieldName := &types.FieldName{
+				DBName:            is.DBName,
+				TblName:           is.Table.Name,
+				ColName:           colInfo.Name,
+				OrigTblName:       is.Table.Name,
+				OrigColName:       colInfo.Name,
+				Hidden:            colInfo.Hidden,
+				NotExplicitUsable: colInfo.State != model.StatePublic,
+			}
 			indexCols = append(indexCols, &expression.Column{
-				ID:       is.Table.Columns[is.Index.Columns[i].Offset].ID,
-				RetType:  &is.Table.Columns[is.Index.Columns[i].Offset].FieldType,
+				ID:       colInfo.ID,
+				RetType:  &colInfo.FieldType,
 				UniqueID: is.ctx.GetSessionVars().AllocPlanColumnID(),
+				OrigName: fieldName.String(),
 			})
 		}
 	}

--- a/tidb/planner/physical_indexscan.go
+++ b/tidb/planner/physical_indexscan.go
@@ -58,8 +58,6 @@ type PhysicalIndexScan struct {
 	KeepOrder bool
 
 	NeedCommonHandle bool
-
-	Covers bool
 }
 
 // Init initializes PhysicalIndexScan.
@@ -103,7 +101,6 @@ func (is *PhysicalIndexScan) initSchema(idxExprCols []*expression.Column, isDoub
 		}
 	}
 	is.NeedCommonHandle = is.Table.IsCommonHandle
-	is.Covers = !isDoubleRead
 
 	if is.NeedCommonHandle {
 		for i := len(is.Index.Columns); i < len(idxExprCols); i++ {


### PR DESCRIPTION
Follow-up to #334.

Appended to the index rows' keys the corresponding PK values from the originating table, so the row can be looked up when there's an index scan using a partially-covering index. The executor gets the values for columns covered by the index, then gets the remaining column values from the originating table for each row.

An index is partially-covering when some, but not all of the columns queried are in the index, and where the "left-most" index column is queried. Index PKs are comprised of `[shardId][tableId][col0][col1]...[colN][tablePKCol0][tablePKCol1]...[tablePKColN]`, so to get the index key prefix, `col0` has to be in the query.