### PR TITLE
Support GZIP encoding in GRPC server

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -22,7 +22,7 @@ import (
 	"github.com/squareup/pranadb/protos/squareup/cash/pranadb/v1/service"
 	"github.com/squareup/pranadb/sess"
 	"google.golang.org/grpc"
-	_ "google.golang.org/grpc/encoding/gzip"
+	_ "google.golang.org/grpc/encoding/gzip" // Registers gzip (de)-compressor
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/protobuf/types/known/emptypb"
 )

--- a/api/server.go
+++ b/api/server.go
@@ -6,11 +6,12 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"github.com/squareup/pranadb/meta"
 	"net"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/squareup/pranadb/meta"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/squareup/pranadb/command"
@@ -21,6 +22,7 @@ import (
 	"github.com/squareup/pranadb/protos/squareup/cash/pranadb/v1/service"
 	"github.com/squareup/pranadb/sess"
 	"google.golang.org/grpc"
+	_ "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/protobuf/types/known/emptypb"
 )


### PR DESCRIPTION
Adds support for GZIP for compression and decompression when requested by the client.

Per https://github.com/grpc/grpc-go/blob/master/Documentation/compression.md#compression