### PR TITLE
Delete range out of band

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -53,7 +53,7 @@ type Cluster interface {
 
 	ExecuteRemotePullQuery(queryInfo *QueryExecutionInfo, rowsFactory *common.RowsFactory) (*common.Rows, error)
 
-	DeleteAllDataInRangeForAllShards(startPrefix []byte, endPrefix []byte) error
+	DeleteAllDataInRangeForAllShardsLocally(startPrefix []byte, endPrefix []byte) error
 
 	DeleteAllDataInRangeForShardLocally(shardID uint64, startPrefix []byte, endPrefix []byte) error
 
@@ -73,7 +73,6 @@ type Cluster interface {
 }
 
 type ToDeleteBatch struct {
-	Local              bool
 	ConditionalTableID uint64
 	Prefixes           [][]byte
 }

--- a/cluster/fake/fake_cluster.go
+++ b/cluster/fake/fake_cluster.go
@@ -312,7 +312,7 @@ func (f *FakeCluster) deleteAllDataInRangeForShard(shardID uint64, startPrefix [
 	return nil
 }
 
-func (f *FakeCluster) DeleteAllDataInRangeForAllShards(startPrefix []byte, endPrefix []byte) error {
+func (f *FakeCluster) DeleteAllDataInRangeForAllShardsLocally(startPrefix []byte, endPrefix []byte) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	for _, shardID := range f.allShardIds {

--- a/command/command.go
+++ b/command/command.go
@@ -365,7 +365,6 @@ func storeToDeleteBatch(tableID uint64, clust cluster.Cluster) (*cluster.ToDelet
 		prefixes = append(prefixes, prefix)
 	}
 	batch := &cluster.ToDeleteBatch{
-		Local:              false,
 		ConditionalTableID: tableID,
 		Prefixes:           prefixes,
 	}

--- a/command/create_source_command.go
+++ b/command/create_source_command.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"github.com/squareup/pranadb/cluster"
 	"sync"
 
 	"github.com/alecthomas/repr"
@@ -24,7 +23,6 @@ type CreateSourceCommand struct {
 	ast            *parser.CreateSource
 	sourceInfo     *common.SourceInfo
 	source         *source.Source
-	toDeleteBatch  *cluster.ToDeleteBatch
 }
 
 func (c *CreateSourceCommand) CommandType() DDLCommandType {
@@ -74,15 +72,7 @@ func (c *CreateSourceCommand) Before() error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	err = c.validate()
-	if err != nil {
-		return err
-	}
-
-	// We store rows in the to_delete table - if source creation fails (e.g. node crashes) then on restart the MV state will
-	// be cleaned up - we have to add a prefix for each shard as the shard id comes first in the key
-	c.toDeleteBatch, err = storeToDeleteBatch(c.sourceInfo.ID, c.e.cluster)
-	return err
+	return c.validate()
 }
 
 func (c *CreateSourceCommand) validate() error {
@@ -160,13 +150,14 @@ func (c *CreateSourceCommand) onPhase0() error {
 			return errors.WithStack(err)
 		}
 	}
+
 	// Create source in push engine so it can receive forwarded rows, do not activate consumers yet
 	src, err := c.e.pushEngine.CreateSource(c.sourceInfo)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 	c.source = src
-	return nil
+	return err
 }
 
 func (c *CreateSourceCommand) onPhase1() error {
@@ -189,12 +180,7 @@ func (c *CreateSourceCommand) AfterPhase(phase int32) error {
 	if phase == 0 {
 		// We persist the source *before* it is registered - otherwise if failure occurs source can disappear after
 		// being used
-		if err := c.e.metaController.PersistSource(c.sourceInfo); err != nil {
-			return err
-		}
-
-		// Now delete rows from the to_delete table
-		return c.e.cluster.RemoveToDeleteBatch(c.toDeleteBatch)
+		return c.e.metaController.PersistSource(c.sourceInfo)
 	}
 	return nil
 }

--- a/command/drop_index_command.go
+++ b/command/drop_index_command.go
@@ -17,7 +17,6 @@ type DropIndexCommand struct {
 	tableName     string
 	indexName     string
 	indexInfo     *common.IndexInfo
-	originating   bool
 	toDeleteBatch *cluster.ToDeleteBatch
 }
 
@@ -43,12 +42,11 @@ func (c *DropIndexCommand) LockName() string {
 
 func NewOriginatingDropIndexCommand(e *Executor, schemaName string, sql string, tableName string, indexName string) *DropIndexCommand {
 	return &DropIndexCommand{
-		e:           e,
-		schemaName:  schemaName,
-		sql:         sql,
-		tableName:   tableName,
-		indexName:   indexName,
-		originating: true,
+		e:          e,
+		schemaName: schemaName,
+		sql:        sql,
+		tableName:  tableName,
+		indexName:  indexName,
 	}
 }
 
@@ -108,7 +106,7 @@ func (c *DropIndexCommand) onPhase1() error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	// This disconnects and removes the data for the index (data removal only happens on the originating node)
-	return c.e.pushEngine.RemoveIndex(c.indexInfo, c.originating)
+	return c.e.pushEngine.RemoveIndex(c.indexInfo)
 }
 
 func (c *DropIndexCommand) AfterPhase(phase int32) error {

--- a/command/drop_mv_command.go
+++ b/command/drop_mv_command.go
@@ -18,7 +18,6 @@ type DropMVCommand struct {
 	mvName        string
 	mv            *push.MaterializedView
 	schema        *common.Schema
-	originating   bool
 	toDeleteBatch *cluster.ToDeleteBatch
 }
 
@@ -44,11 +43,10 @@ func (c *DropMVCommand) LockName() string {
 
 func NewOriginatingDropMVCommand(e *Executor, schemaName string, sql string, mvName string) *DropMVCommand {
 	return &DropMVCommand{
-		e:           e,
-		schemaName:  schemaName,
-		sql:         sql,
-		mvName:      mvName,
-		originating: true,
+		e:          e,
+		schemaName: schemaName,
+		sql:        sql,
+		mvName:     mvName,
 	}
 }
 
@@ -128,8 +126,7 @@ func (c *DropMVCommand) onPhase1() error {
 	if err := c.e.pushEngine.RemoveMV(c.mv.Info.ID); err != nil {
 		return errors.WithStack(err)
 	}
-	// We only delete the data from the originating node - otherwise all nodes would be deleting the same data
-	return c.mv.Drop(c.originating)
+	return c.mv.Drop()
 }
 
 func (c *DropMVCommand) AfterPhase(phase int32) error {

--- a/command/drop_source_command.go
+++ b/command/drop_source_command.go
@@ -16,7 +16,6 @@ type DropSourceCommand struct {
 	sql           string
 	sourceName    string
 	sourceInfo    *common.SourceInfo
-	originating   bool
 	toDeleteBatch *cluster.ToDeleteBatch
 }
 
@@ -42,11 +41,10 @@ func (c *DropSourceCommand) LockName() string {
 
 func NewOriginatingDropSourceCommand(e *Executor, schemaName string, sql string, sourceName string) *DropSourceCommand {
 	return &DropSourceCommand{
-		e:           e,
-		schemaName:  schemaName,
-		sql:         sql,
-		sourceName:  sourceName,
-		originating: true,
+		e:          e,
+		schemaName: schemaName,
+		sql:        sql,
+		sourceName: sourceName,
 	}
 }
 
@@ -127,11 +125,7 @@ func (c *DropSourceCommand) onPhase1() error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	if c.originating {
-		// We only delete the data from the originating node - otherwise all nodes would be deleting the same data
-		return src.Drop()
-	}
-	return nil
+	return src.Drop()
 }
 
 func (c *DropSourceCommand) AfterPhase(phase int32) error {

--- a/pull/exec/remote_executor_test.go
+++ b/pull/exec/remote_executor_test.go
@@ -166,6 +166,10 @@ type testCluster struct {
 	rowsByShardOrig map[uint64]*common.Rows
 }
 
+func (t *testCluster) DeleteAllDataInRangeForAllShardsLocally(startPrefix []byte, endPrefix []byte) error {
+	return nil
+}
+
 func (t *testCluster) WriteForwardBatch(batch *cluster.WriteBatch) error {
 	return nil
 }

--- a/push/engine.go
+++ b/push/engine.go
@@ -249,7 +249,7 @@ func (p *Engine) CreateIndex(indexInfo *common.IndexInfo, fill bool) error {
 	return nil
 }
 
-func (p *Engine) RemoveIndex(indexInfo *common.IndexInfo, deleteData bool) error {
+func (p *Engine) RemoveIndex(indexInfo *common.IndexInfo) error {
 	te, err := p.getTableExecutorForIndex(indexInfo)
 	if err != nil {
 		return err
@@ -257,13 +257,10 @@ func (p *Engine) RemoveIndex(indexInfo *common.IndexInfo, deleteData bool) error
 	consumerName := fmt.Sprintf("%s.%s", te.TableInfo.Name, indexInfo.Name)
 	te.RemoveConsumingNode(consumerName)
 
-	if deleteData {
-		// Delete the table data
-		tableStartPrefix := common.AppendUint64ToBufferBE(nil, indexInfo.ID)
-		tableEndPrefix := common.AppendUint64ToBufferBE(nil, indexInfo.ID+1)
-		return p.cluster.DeleteAllDataInRangeForAllShards(tableStartPrefix, tableEndPrefix)
-	}
-	return nil
+	// Delete the table data
+	tableStartPrefix := common.AppendUint64ToBufferBE(nil, indexInfo.ID)
+	tableEndPrefix := common.AppendUint64ToBufferBE(nil, indexInfo.ID+1)
+	return p.cluster.DeleteAllDataInRangeForAllShardsLocally(tableStartPrefix, tableEndPrefix)
 }
 
 func (p *Engine) getTableExecutorForIndex(indexInfo *common.IndexInfo) (*exec.TableExecutor, error) {

--- a/push/exec/table_exec.go
+++ b/push/exec/table_exec.go
@@ -216,7 +216,6 @@ func (t *TableExecutor) addFillTableToDelete(newTableID uint64, fillTableID uint
 		prefixes = append(prefixes, prefix)
 	}
 	batch := &cluster.ToDeleteBatch{
-		Local:              true,
 		ConditionalTableID: newTableID,
 		Prefixes:           prefixes,
 	}

--- a/push/mv.go
+++ b/push/mv.go
@@ -65,16 +65,13 @@ func (m *MaterializedView) Disconnect() error {
 	return m.disconnectOrDeleteDataForMV(m.schema, m.tableExecutor, true, false)
 }
 
-func (m *MaterializedView) Drop(deleteData bool) error {
+func (m *MaterializedView) Drop() error {
 	// Will already have been disconnected
-	err := m.disconnectOrDeleteDataForMV(m.schema, m.tableExecutor, false, deleteData)
+	err := m.disconnectOrDeleteDataForMV(m.schema, m.tableExecutor, false, true)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	if deleteData {
-		return m.deleteTableData(m.Info.ID)
-	}
-	return nil
+	return m.deleteTableData(m.Info.ID)
 }
 
 func (m *MaterializedView) disconnectOrDeleteDataForMV(schema *common.Schema, node exec.PushExecutor, disconnect bool, deleteData bool) error {
@@ -137,7 +134,7 @@ func (m *MaterializedView) disconnectOrDeleteDataForMV(schema *common.Schema, no
 func (m *MaterializedView) deleteTableData(tableID uint64) error {
 	startPrefix := common.AppendUint64ToBufferBE(nil, tableID)
 	endPrefix := common.AppendUint64ToBufferBE(nil, tableID+1)
-	return m.cluster.DeleteAllDataInRangeForAllShards(startPrefix, endPrefix)
+	return m.cluster.DeleteAllDataInRangeForAllShardsLocally(startPrefix, endPrefix)
 }
 
 func (m *MaterializedView) addConsumingExecutor(mvName string, executor exec.PushExecutor) {

--- a/push/source/source.go
+++ b/push/source/source.go
@@ -207,15 +207,16 @@ func (s *Source) IsRunning() bool {
 func (s *Source) Drop() error {
 	// Delete the deduplication ids for the source
 	startPrefix := common.AppendUint64ToBufferBE(nil, common.ForwardDedupTableID)
+	startPrefix = common.AppendUint64ToBufferBE(startPrefix, s.sourceInfo.ID)
 	endPrefix := common.IncrementBytesBigEndian(startPrefix)
-	if err := s.cluster.DeleteAllDataInRangeForAllShards(startPrefix, endPrefix); err != nil {
+	if err := s.cluster.DeleteAllDataInRangeForAllShardsLocally(startPrefix, endPrefix); err != nil {
 		return errors.WithStack(err)
 	}
 
 	// Delete the table data
 	tableStartPrefix := common.AppendUint64ToBufferBE(nil, s.sourceInfo.ID)
 	tableEndPrefix := common.AppendUint64ToBufferBE(nil, s.sourceInfo.ID+1)
-	return s.cluster.DeleteAllDataInRangeForAllShards(tableStartPrefix, tableEndPrefix)
+	return s.cluster.DeleteAllDataInRangeForAllShardsLocally(tableStartPrefix, tableEndPrefix)
 }
 
 func (s *Source) AddConsumingExecutor(mvName string, executor exec.PushExecutor) {

--- a/push/util/util.go
+++ b/push/util/util.go
@@ -24,7 +24,7 @@ import (
 
 func EncodeKeyForForwardIngest(sourceID uint64, partitionID uint64, offset uint64, remoteConsumerID uint64) []byte {
 	buff := make([]byte, 0, 33)
-	buff = append(buff, 1)
+	buff = append(buff, 1) // This byte means duplicated detection is enabled
 	// The first 24 bytes is the dedup key and comprises [originator_id (16 bytes), sequence (8 bytes)]
 	// Originator id for an ingest from Kafka comprises [source_id (8 bytes), partition_id (8 bytes) ]
 	buff = common.AppendUint64ToBufferBE(buff, sourceID)

--- a/sqltest/sql_large_cluster_test.go
+++ b/sqltest/sql_large_cluster_test.go
@@ -1,3 +1,4 @@
+//go:build largecluster
 // +build largecluster
 
 package sqltest

--- a/sqltest/sql_test.go
+++ b/sqltest/sql_test.go
@@ -1,3 +1,4 @@
+//go:build !largecluster
 // +build !largecluster
 
 package sqltest


### PR DESCRIPTION
With this PR we now delete all table data (i.e. that which occurs at drop of source/mv/index) out of band. That means we don't execute the delete range via Raft - we execute it directly in Pebble.
Deleting ranges can be an expensive operation and we don't want to lock up the shard state machine while that is happening.

Closes #376 