### PR TITLE
Optimise index scans

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -308,7 +308,7 @@ func describeRows(tableInfo *common.TableInfo) (exec.PullExecutor, error) {
 		}
 		resultRows.AppendStringToColumn(0, columnName)
 		resultRows.AppendStringToColumn(1, tableInfo.ColumnTypes[columnIndex].String())
-		if tableInfo.IsPrimaryKey(columnIndex) {
+		if tableInfo.IsPrimaryKeyCol(columnIndex) {
 			resultRows.AppendStringToColumn(2, "pk")
 		} else {
 			resultRows.AppendStringToColumn(2, "")


### PR DESCRIPTION
This PR optimises and simplifies the index reader logic. Previously, various arrays were being calculated on every invocation to getRows, and the logic for decoding columns from index or pk was overly complex and included inner loops (Contains() method).
All pre-calculations have been moved to the creation of the executor. And now, we use two mapping arrays to determine which columns from the index/pk we need to include. This signifies the logic and means we don't have to do any O(N^2) or worse traversals in perf sensitive code.