### PR TITLE
Implement multiple ranges for index scan

### DIFF
--- a/pull/exec/index_reader_test.go
+++ b/pull/exec/index_reader_test.go
@@ -125,6 +125,27 @@ func TestReadIndexCovers(t *testing.T) {
 	ranges = createSimpleRanges(int64(2), int64(2), false, false)
 	testReadIndex(t, indexCols, pkCols, ranges, tableColIndexes, inpRows, tableColNames, tableColTypes, expectedRows, expectedColTypes)
 
+	//Test with multiple ranges - this would be triggered, say, by an IN clause selecting multiple values from secondary index
+	expectedRows = [][]interface{}{
+		{2, "bbb"},
+		{2, "ccc"},
+		{1, "aaa"},
+	}
+	scanRange1 := &ScanRange{
+		LowVals:  []interface{}{int64(2)},
+		HighVals: []interface{}{int64(2)},
+		LowExcl:  false,
+		HighExcl: false,
+	}
+	scanRange2 := &ScanRange{
+		LowVals:  []interface{}{int64(1)},
+		HighVals: []interface{}{int64(1)},
+		LowExcl:  false,
+		HighExcl: false,
+	}
+	ranges = []*ScanRange{scanRange1, scanRange2}
+	testReadIndex(t, indexCols, pkCols, ranges, tableColIndexes, inpRows, tableColNames, tableColTypes, expectedRows, expectedColTypes)
+
 	// Just the PK
 	tableColIndexes = []int{0}
 	expectedColTypes = []common.ColumnType{common.BigIntColumnType}
@@ -259,6 +280,7 @@ func TestCompositeIndex(t *testing.T) {
 	}
 	ranges = []*ScanRange{scanRange}
 	testReadIndex(t, indexCols, pkCols, ranges, tableColIndexes, inpRows, tableColNames, tableColTypes, expectedRows, expectedColTypes)
+
 }
 
 func createSimpleRanges(lowVal interface{}, highVal interface{}, lowExcl bool, highExcl bool) []*ScanRange {

--- a/pull/exec_builder.go
+++ b/pull/exec_builder.go
@@ -175,9 +175,6 @@ func (p *Engine) createPullIndexScan(schema *common.Schema, tableName string, in
 	if !ok {
 		return nil, errors.Errorf("unknown index %s", indexName)
 	}
-	if len(ranges) > 1 {
-		return nil, errors.Error("multiple ranges not supported")
-	}
 	scanRanges := createScanRanges(ranges)
 	var colIndexes []int
 	for _, colInfo := range columnInfos {

--- a/sqltest/testdata/planner_index_test_out.txt
+++ b/sqltest/testdata/planner_index_test_out.txt
@@ -83,6 +83,14 @@ select * from transactions where id < 5 order by id;
 |4|400|null|
 4 rows returned
 
+-- this should trigger multiple ranges for an index scan;
+select * from transactions where customer_id in (500, 600, 700) order by id;
+|id|customer_id|col2|
+|5|500|abc|
+|6|600|abc|
+|7|600|abc|
+3 rows returned
+
 drop index index1 on transactions;
 0 rows returned
 
@@ -160,6 +168,14 @@ select * from transactions where customer_id = 400 and col2 is null order by id;
 |id|customer_id|col2|
 |4|400|null|
 1 rows returned
+
+-- this should trigger multiple ranges for an index scan;
+select * from transactions where customer_id in (500, 600, 700) and col2 in ('abc', 'ghi') order by id;
+|id|customer_id|col2|
+|5|500|abc|
+|6|600|abc|
+|7|600|abc|
+3 rows returned
 
 drop index index2 on transactions;
 0 rows returned

--- a/sqltest/testdata/planner_index_test_script.txt
+++ b/sqltest/testdata/planner_index_test_script.txt
@@ -42,6 +42,9 @@ select * from transactions where id > 5 order by id;
 
 select * from transactions where id < 5 order by id;
 
+-- this should trigger multiple ranges for an index scan;
+select * from transactions where customer_id in (500, 600, 700) order by id;
+
 drop index index1 on transactions;
 
 --test multi-col index;
@@ -71,6 +74,9 @@ select customer_id, id, col2 from transactions where customer_id > 300 and col2 
 select * from transactions where customer_id = 300 and col2 = 'ghi' order by id;
 
 select * from transactions where customer_id = 400 and col2 is null order by id;
+
+-- this should trigger multiple ranges for an index scan;
+select * from transactions where customer_id in (500, 600, 700) and col2 in ('abc', 'ghi') order by id;
 
 drop index index2 on transactions;
 


### PR DESCRIPTION
This PR implements multiple ranges for index scans.

Multiple ranges can occur when an IN clause is used in the query to select multiple distinct values from the index, e.g.

```
select * from transactions where customer_id in ('cust123', 'cust543', 'cust765');
```
