### PR TITLE
Configure GitHub release of Prana CLI binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,20 +6,19 @@ name: Release
 jobs:
   deployable:
     name: Release
+    needs: ci
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16.3'
+          go-version: '^1.18'
       - run: ./bin/hermit env --raw >> $GITHUB_ENV
       - name: Build Prana
         run: |
-          make GOOS=linux GOARCH=amd64 CHANNEL=stable build
-          make GOOS=linux GOARCH=arm64 CHANNEL=stable build
-          make GOOS=darwin GOARCH=amd64 CHANNEL=stable build
-          make GOOS=darwin GOARCH=arm64 CHANNEL=stable build
+          make GOOS=linux GOARCH=amd64 CHANNEL=stable build-cli
+          make GOOS=darwin GOARCH=amd64 CHANNEL=stable build-cli
       - name: Release versioned
         uses: ncipollo/release-action@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ build: protos ## builds binary and gzips it
 	go build -tags musl -o $(BIN) ./cmd/pranadb
 	gzip -9 -f $(BIN)/pranadb
 
+build-cli: protos ## builds CLI binary and gzips it
+	mkdir -p $(BIN)
+	go build -o $(BIN) ./cmd/prana
+	gzip -9 -f $(BIN)/prana
+
 test: protos
 	go test -race -short -timeout 30s ./...
 


### PR DESCRIPTION
This PR adds build and release for PranaDB CLI. PranaDB server binaries will be released as Docker images in subsequent PRs.

https://github.com/squareup/pranadb-internal/issues/28