### PR TITLE
Remove CI job dependency during release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,6 @@ name: Release
 jobs:
   deployable:
     name: Release
-    needs: ci
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
This PR removes the dependency on running CI job when releasing. CI job runs on push to master. This fixes [current error](https://github.com/cashapp/pranadb/actions/runs/2546816661/workflow):

```
The workflow is not valid. .github/workflows/release.yaml (Line: 7, Col: 3): The workflow must contain at least one job with no dependencies.
```

https://github.com/squareup/pranadb-internal/issues/28