### PR TITLE
Added Close method to PullExecutor

### DIFF
--- a/pull/exec/chain.go
+++ b/pull/exec/chain.go
@@ -66,3 +66,11 @@ func (c *PullChain) ColTypes() []common.ColumnType {
 func (c *PullChain) SetColNames(colNames []string) {
 	c.colNames = colNames
 }
+
+func (c *PullChain) RowsFactory() *common.RowsFactory {
+	return c.first().RowsFactory()
+}
+
+func (c *PullChain) Close() {
+	c.first().Close()
+}

--- a/pull/exec/exec.go
+++ b/pull/exec/exec.go
@@ -25,6 +25,8 @@ type PullExecutor interface {
 	ColNames() []string
 	ColTypes() []common.ColumnType
 	SetColNames(colNames []string)
+	RowsFactory() *common.RowsFactory
+	Close()
 }
 
 type pullExecutorBase struct {
@@ -66,6 +68,16 @@ func (p *pullExecutorBase) ColTypes() []common.ColumnType {
 
 func (p *pullExecutorBase) SetColNames(colNames []string) {
 	p.colNames = colNames
+}
+
+func (p *pullExecutorBase) RowsFactory() *common.RowsFactory {
+	return p.rowsFactory
+}
+
+func (p *pullExecutorBase) Close() {
+	for _, child := range p.children {
+		child.Close()
+	}
 }
 
 func ConnectPullExecutors(childExecutors []PullExecutor, parent PullExecutor) {

--- a/pull/exec/exec.go
+++ b/pull/exec/exec.go
@@ -81,6 +81,7 @@ func (p *pullExecutorBase) Close() {
 }
 
 func ConnectPullExecutors(childExecutors []PullExecutor, parent PullExecutor) {
+	
 	for _, child := range childExecutors {
 		child.SetParent(parent)
 		parent.AddChild(child)

--- a/pull/exec/exec.go
+++ b/pull/exec/exec.go
@@ -81,7 +81,6 @@ func (p *pullExecutorBase) Close() {
 }
 
 func ConnectPullExecutors(childExecutors []PullExecutor, parent PullExecutor) {
-	
 	for _, child := range childExecutors {
 		child.SetParent(parent)
 		parent.AddChild(child)

--- a/pull/exec/utils_for_test.go
+++ b/pull/exec/utils_for_test.go
@@ -80,3 +80,10 @@ func (r *rowProvider) GetParent() PullExecutor {
 func (r *rowProvider) GetChildren() []PullExecutor {
 	return nil
 }
+
+func (r *rowProvider) Close() {
+}
+
+func (r *rowProvider) RowsFactory() *common.RowsFactory {
+	return nil
+}

--- a/sqltest/sql_test_runner.go
+++ b/sqltest/sql_test_runner.go
@@ -510,7 +510,7 @@ func (st *sqlTest) runTestIteration(require *require.Assertions, commands []stri
 			return num == 0, nil
 		}, 5*time.Second, 10*time.Millisecond)
 		require.NoError(err)
-		require.True(ok, "timed out waiting for num remote sessions to get to zero")
+		require.True(ok, "timed out waiting for num remote execution contexts to get to zero")
 
 		topicNames := st.testSuite.fakeKafka.GetTopicNames()
 		if len(topicNames) > 0 {


### PR DESCRIPTION
This is called to clear up resources of the DAG if a query is completed before all rows returned. E.g. in the case of LIMIT.
The close is propagated to remote nodes by using the value of zero as the limit - this triggers the remote node to remove the query execution context from the cache.

Closes https://github.com/cashapp/pranadb/issues/361