### PR TITLE
CLI improvements: Exit cleanly on CTRL-C or connection error and cleaner exception messages

### DIFF
--- a/cmd/prana/commands/shell.go
+++ b/cmd/prana/commands/shell.go
@@ -40,6 +40,10 @@ func (c *ShellCommand) Run(cl *client.Client) error {
 				return nil
 			}
 			if err != nil {
+				if err.Error() == "Interrupt" {
+					// This occurs when CTRL-C is pressed - we should exit silently
+					return nil
+				}
 				return errors.WithStack(err)
 			}
 			line = strings.TrimSpace(line)

--- a/sqltest/testdata/cli_formatting_test_out.txt
+++ b/sqltest/testdata/cli_formatting_test_out.txt
@@ -59,22 +59,22 @@ set max_line_width 50;
 0 rows returned
 
 set foo 123;
-Unknown property: foo
+Failed to execute statement: Unknown property: foo
 
 set max_line_width oranges;
-Invalid max_line_width value: oranges
+Failed to execute statement: Invalid max_line_width value: oranges
 
 set max_line_width 0;
-Invalid max_line_width value: 0
+Failed to execute statement: Invalid max_line_width value: 0
 
 set max_line_width -1;
-Invalid max_line_width value: -1
+Failed to execute statement: Invalid max_line_width value: -1
 
 set bar;
-Invalid set command. Should be set <prop_name> <prop_value>
+Failed to execute statement: Invalid set command. Should be set <prop_name> <prop_value>
 
 set;
-Invalid set command. Should be set <prop_name> <prop_value>
+Failed to execute statement: Invalid set command. Should be set <prop_name> <prop_value>
 
 set max_line_width 80;
 0 rows returned


### PR DESCRIPTION
Now we:
* Exit cleanly without a big stack trace on CTRL-C
* Connection errors cause the CLI to exit
* Cleanup of some exception messages

Closes https://github.com/cashapp/pranadb/issues/198