### PR TITLE
Tag main branch on successful push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,10 @@ jobs:
         run: make -C protos lint
       - name: Test
         run: go test -race -count=1 -timeout 1h -failfast -p 1 -tags integration ./...
+      - name: Bump version and push tag
+        id: bump_version
+        uses: anothrNick/github-tag-action@1.39.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+          DEFAULT_BUMP: patch


### PR DESCRIPTION
This PR configures a GitHub action that will tag the `main` branch on successful push. The tag is the current release version with the `patch` version incremented. Major and minor version number remain the same as the last release.
https://github.com/squareup/pranadb-internal/issues/28