### PR TITLE
Revert release tagging which was being run every time CI was run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,3 @@ jobs:
         run: make -C protos lint
       - name: Test
         run: go test -race -count=1 -timeout 1h -failfast -p 1 -tags integration ./...
-      - name: Bump version and push tag
-        id: bump_version
-        uses: anothrNick/github-tag-action@1.39.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WITH_V: true
-          DEFAULT_BUMP: patch


### PR DESCRIPTION
This reverts https://github.com/cashapp/pranadb/pull/442 which was causing CI builds on PRs to fail as it was running every time CI was run on a PR. I think the intention was to run only on successful merge to main?

E.g. error:
```

*** CONFIGURATION ***
[13](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:14)
	DEFAULT_BUMP: patch
[14](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:15)
	WITH_V: true
[15](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:16)
	RELEASE_BRANCHES: master,main
[16](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:17)
	CUSTOM_TAG: 
[17](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:18)
	SOURCE: .
[18](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:19)
	DRY_RUN: false
[19](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:20)
	INITIAL_VERSION: 0.0.0
[20](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:21)
	TAG_CONTEXT: repo
[21](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:22)
	PRERELEASE_SUFFIX: beta
[22](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:23)
	VERBOSE: true
[23](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:24)
Is master a match for HEAD
[24](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:25)
Is main a match for HEAD
[25](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:26)
pre_release = true
[26](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:27)
From https://github.com/cashapp/pranadb
[27](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:28)
 * [new branch]      acarrington/planner-uses-indexes -> origin/acarrington/planner-uses-indexes
[28](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:29)
 * [new branch]      buffer_snapshot      -> origin/buffer_snapshot
[29](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:30)
 * [new branch]      dragoncopy_etc       -> origin/dragoncopy_etc
[30](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:31)
 * [new branch]      index_scan_sql_tests -> origin/index_scan_sql_tests
[31](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:32)
 * [new branch]      main                 -> origin/main
[32](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:33)
 * [new branch]      more_phys_plan_tests -> origin/more_phys_plan_tests
[33](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:34)
 * [new branch]      oob_queries          -> origin/oob_queries
[34](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:35)
 * [new branch]      out_of_band_delete_prefix -> origin/out_of_band_delete_prefix
[35](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:36)
 * [new branch]      verifier_tool        -> origin/verifier_tool
[36](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:37)
 * [new tag]         stable               -> stable
[37](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:38)
 * [new tag]         v0.1.0               -> v0.1.0
[38](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:39)
 * [new tag]         v0.1.1               -> v0.1.1
[39](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:40)
 * [new tag]         v0.1.1-beta.1        -> v0.1.1-beta.1
[40](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:41)
 * [new tag]         v0.1.2               -> v0.1.2
[41](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:42)
 * [new tag]         v0.1.2-beta.1        -> v0.1.2-beta.1
[42](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:43)
 * [new tag]         v0.1.3-beta.1        -> v0.1.3-beta.1
[43](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:44)
fatal: ambiguous argument '0.1.2..HEAD': unknown revision or path not in the working tree.
[44](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:45)
Use '--' to separate paths from revisions, like this:
[45](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:46)
'git <command> [<revision>...] -- [<file>...]'
[46](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:47)
fatal: ambiguous argument '0.1.2': unknown revision or path not in the working tree.
[47](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:48)
Use '--' to separate paths from revisions, like this:
[48](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:49)
'git <command> [<revision>...] -- [<file>...]'
[49](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:50)

[50](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:51)
pre-patch
[51](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:52)
Bumping tag . 
[52](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:53)
	New tag v0.1.3-beta.1
[53](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:54)
fatal: tag 'v0.1.3-beta.1' already exists
[54](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:55)
2022-07-06T14:03:11Z: **pushing tag v0.1.3-beta.1 to repo cashapp/pranadb
[55](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:56)
  "message": "Reference already exists",
[56](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:57)
  "documentation_url": "https://docs.github.com/rest/reference/git#create-a-reference"
[57](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:58)
}
[58](https://github.com/cashapp/pranadb/runs/7215932611?check_suite_focus=true#step:10:59)
Error: Tag was not created properly.
```