### PR TITLE
Remove partial aggregations and fix duplicate detection

### DIFF
--- a/aggfuncs/aggfuncs.go
+++ b/aggfuncs/aggfuncs.go
@@ -12,12 +12,6 @@ type AggregateFunction interface {
 	EvalTimestamp(value common.Timestamp, null bool, aggState *AggState, index int, reverse bool) error
 	EvalDecimal(value common.Decimal, null bool, aggState *AggState, index int, reverse bool) error
 
-	MergeInt64(latestState *AggState, aggState *AggState, index int, reverse bool) error
-	MergeFloat64(latestState *AggState, aggState *AggState, index int, reverse bool) error
-	MergeString(latestState *AggState, aggState *AggState, index int, reverse bool) error
-	MergeTimestamp(latestState *AggState, aggState *AggState, index int, reverse bool) error
-	MergeDecimal(latestState *AggState, aggState *AggState, index int, reverse bool) error
-
 	ValueType() common.ColumnType
 	ArgExpression() *common.Expression
 	RequiresExtraState() bool
@@ -45,26 +39,6 @@ func (b *aggregateFunctionBase) EvalTimestamp(value common.Timestamp, null bool,
 }
 
 func (b *aggregateFunctionBase) EvalDecimal(value common.Decimal, null bool, aggState *AggState, index int, reverse bool) error {
-	panic("should not be called")
-}
-
-func (b *aggregateFunctionBase) MergeInt64(latestState *AggState, aggState *AggState, index int, reverse bool) error {
-	panic("should not be called")
-}
-
-func (b *aggregateFunctionBase) MergeFloat64(latestState *AggState, aggState *AggState, index int, reverse bool) error {
-	panic("should not be called")
-}
-
-func (b *aggregateFunctionBase) MergeString(latestState *AggState, aggState *AggState, index int, reverse bool) error {
-	panic("should not be called")
-}
-
-func (b *aggregateFunctionBase) MergeTimestamp(latestState *AggState, aggState *AggState, index int, reverse bool) error {
-	panic("should not be called")
-}
-
-func (b *aggregateFunctionBase) MergeDecimal(latestState *AggState, aggState *AggState, index int, reverse bool) error {
 	panic("should not be called")
 }
 

--- a/aggfuncs/standard_aggfuncs.go
+++ b/aggfuncs/standard_aggfuncs.go
@@ -48,16 +48,6 @@ func (s *SumAggregateFunction) EvalDecimal(value common.Decimal, null bool, aggS
 	return aggState.SetDecimal(index, *newVal)
 }
 
-func (s *SumAggregateFunction) MergeFloat64(latestState *AggState, aggState *AggState, index int, reverse bool) error {
-	value := latestState.GetFloat64(index)
-	return s.EvalFloat64(value, false, aggState, index, reverse)
-}
-
-func (s *SumAggregateFunction) MergeDecimal(latestState *AggState, aggState *AggState, index int, reverse bool) error {
-	value := latestState.GetDecimal(index)
-	return s.EvalDecimal(value, false, aggState, index, reverse)
-}
-
 // COUNT
 // =====
 
@@ -75,19 +65,6 @@ func (c *CountAggregateFunction) EvalInt64(value int64, null bool, aggState *Agg
 		newVal = currVal - 1
 	} else {
 		newVal = currVal + 1
-	}
-	aggState.SetInt64(index, newVal)
-	return nil
-}
-
-func (c *CountAggregateFunction) MergeInt64(toMerge *AggState, aggState *AggState, index int, reverse bool) error {
-	value := toMerge.GetInt64(index)
-	currVal := aggState.GetInt64(index)
-	var newVal int64
-	if reverse {
-		newVal = currVal - value
-	} else {
-		newVal = currVal + value
 	}
 	aggState.SetInt64(index, newVal)
 	return nil
@@ -156,70 +133,6 @@ func (f *FirstRowAggregateFunction) EvalDecimal(value common.Decimal, null bool,
 		aggState.SetNull(index)
 	} else if err := aggState.SetDecimal(index, value); err != nil {
 		return err
-	}
-	return nil
-}
-
-func (f *FirstRowAggregateFunction) MergeInt64(latestState *AggState, aggState *AggState, index int, reverse bool) error {
-	if aggState.IsSet(index) {
-		return nil
-	}
-	if latestState.IsNull(index) {
-		aggState.SetNull(index)
-	} else {
-		aggState.SetInt64(index, latestState.GetInt64(index))
-	}
-	return nil
-}
-
-func (f *FirstRowAggregateFunction) MergeFloat64(latestState *AggState, aggState *AggState, index int, reverse bool) error {
-	if aggState.IsSet(index) {
-		return nil
-	}
-	if latestState.IsNull(index) {
-		aggState.SetNull(index)
-	} else {
-		aggState.SetFloat64(index, latestState.GetFloat64(index))
-	}
-	return nil
-}
-
-func (f *FirstRowAggregateFunction) MergeString(latestState *AggState, aggState *AggState, index int, reverse bool) error {
-	if aggState.IsSet(index) {
-		return nil
-	}
-	if latestState.IsNull(index) {
-		aggState.SetNull(index)
-	} else {
-		aggState.SetString(index, latestState.GetString(index))
-	}
-	return nil
-}
-
-func (f *FirstRowAggregateFunction) MergeDecimal(latestState *AggState, aggState *AggState, index int, reverse bool) error {
-	if aggState.IsSet(index) {
-		return nil
-	}
-	if latestState.IsNull(index) {
-		aggState.SetNull(index)
-	} else {
-		return aggState.SetDecimal(index, latestState.GetDecimal(index))
-	}
-	return nil
-}
-
-func (f *FirstRowAggregateFunction) MergeTimestamp(latestState *AggState, aggState *AggState, index int, reverse bool) error {
-	if aggState.IsSet(index) {
-		return nil
-	}
-	if latestState.IsNull(index) {
-		aggState.SetNull(index)
-	} else {
-		ts, err := latestState.GetTimestamp(index)
-		if err != nil {
-			return err
-		}
-		return aggState.SetTimestamp(index, ts)
 	}
 	return nil
 }

--- a/push/exec/aggregator.go
+++ b/push/exec/aggregator.go
@@ -12,12 +12,11 @@ import (
 
 type Aggregator struct {
 	pushExecutorBase
-	aggFuncs            []aggfuncs.AggregateFunction
-	PartialAggTableInfo *common.TableInfo
-	FullAggTableInfo    *common.TableInfo
-	groupByCols         []int // The group by column indexes in the child
-	storage             cluster.Cluster
-	sharder             *sharder.Sharder
+	aggFuncs     []aggfuncs.AggregateFunction
+	AggTableInfo *common.TableInfo
+	groupByCols  []int // The group by column indexes in the child
+	storage      cluster.Cluster
+	sharder      *sharder.Sharder
 }
 
 type AggregateFunctionInfo struct {
@@ -36,14 +35,13 @@ type aggStateHolder struct {
 	row             *common.Row
 }
 
-func NewAggregator(pkCols []int, aggFunctions []*AggregateFunctionInfo, partialAggTableInfo *common.TableInfo,
-	fullAggTableInfo *common.TableInfo, groupByCols []int, storage cluster.Cluster, sharder *sharder.Sharder) (*Aggregator, error) {
+func NewAggregator(pkCols []int, aggFunctions []*AggregateFunctionInfo, fullAggTableInfo *common.TableInfo,
+	groupByCols []int, storage cluster.Cluster, sharder *sharder.Sharder) (*Aggregator, error) {
 
 	colTypes := make([]common.ColumnType, len(aggFunctions))
 	for i, aggFunc := range aggFunctions {
 		colTypes[i] = aggFunc.ReturnType
 	}
-	partialAggTableInfo.ColumnTypes = colTypes
 	fullAggTableInfo.ColumnTypes = colTypes
 	rf := common.NewRowsFactory(colTypes)
 	pushBase := pushExecutorBase{
@@ -56,13 +54,12 @@ func NewAggregator(pkCols []int, aggFunctions []*AggregateFunctionInfo, partialA
 		return nil, errors.WithStack(err)
 	}
 	return &Aggregator{
-		pushExecutorBase:    pushBase,
-		aggFuncs:            aggFuncs,
-		PartialAggTableInfo: partialAggTableInfo,
-		FullAggTableInfo:    fullAggTableInfo,
-		groupByCols:         groupByCols,
-		storage:             storage,
-		sharder:             sharder,
+		pushExecutorBase: pushBase,
+		aggFuncs:         aggFuncs,
+		AggTableInfo:     fullAggTableInfo,
+		groupByCols:      groupByCols,
+		storage:          storage,
+		sharder:          sharder,
 	}, nil
 }
 
@@ -73,14 +70,70 @@ type stateHolders struct {
 
 func (a *Aggregator) HandleRows(rowsBatch RowsBatch, ctx *ExecutionContext) error {
 
-	// We first calculate the partial aggregations locally
+	// Forward the rows to the shard which owns the group by key
+	numRows := rowsBatch.Len()
+	for i := 0; i < numRows; i++ {
+		prevRow := rowsBatch.PreviousRow(i)
+		currRow := rowsBatch.CurrentRow(i)
+		var row *common.Row
+		if currRow != nil {
+			row = currRow
+		} else {
+			row = prevRow
+		}
+		colTypes := a.GetChildren()[0].ColTypes()
+		keyBytes, err := common.EncodeKeyCols(row, a.groupByCols, colTypes, nil)
+		if err != nil {
+			return err
+		}
+		remoteShardID, err := a.sharder.CalculateShard(sharder.ShardTypeHash, keyBytes)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// TODO optimisation - pass through row bytes so don't have to re-encode
+		var prevRowBytes []byte
+		if prevRow != nil {
+			prevRowBytes, err = common.EncodeRow(prevRow, colTypes, nil)
+			if err != nil {
+				return err
+			}
+		}
+		var currRowBytes []byte
+		if currRow != nil {
+			currRowBytes, err = common.EncodeRow(currRow, colTypes, nil)
+			if err != nil {
+				return err
+			}
+		}
+
+		receiverSeq := rowsBatch.ReceiverIndex(i)
+		if receiverSeq == 0 && ctx.EnableDuplicateDetection {
+			// sanity check
+			// a valid receiver sequence is never equal to zero - they always start at 1 so we know that it's
+			// undefined here and we can't create a valid dedup key
+			panic("undefined receiver sequence in attempting to forward aggregation")
+		}
+		forwardKey := util.EncodeKeyForForwardAggregation(ctx.EnableDuplicateDetection, a.AggTableInfo.ID,
+			ctx.WriteBatch.ShardID, uint64(receiverSeq), a.AggTableInfo.ID)
+		value := util.EncodePrevAndCurrentRow(prevRowBytes, currRowBytes)
+		ctx.AddToForwardBatch(remoteShardID, forwardKey, value)
+	}
+
+	return nil
+}
+
+// HandleRemoteRows is called when partial aggregation is forwarded from another shard
+func (a *Aggregator) HandleRemoteRows(rowsBatch RowsBatch, ctx *ExecutionContext) error {
+
+	// Calculate the aggregations
 	holders := &stateHolders{holdersMap: make(map[string]*aggStateHolder)}
 	numRows := rowsBatch.Len()
 	readRows := a.rowsFactory.NewRows(numRows)
 	for i := 0; i < numRows; i++ {
 		prevRow := rowsBatch.PreviousRow(i)
 		currentRow := rowsBatch.CurrentRow(i)
-		if err := a.calcPartialAggregations(prevRow, currentRow, readRows, holders, ctx.WriteBatch.ShardID); err != nil {
+		if err := a.calcAggregations(prevRow, currentRow, readRows, holders, ctx.WriteBatch.ShardID); err != nil {
 			return err
 		}
 	}
@@ -90,60 +143,12 @@ func (a *Aggregator) HandleRows(rowsBatch RowsBatch, ctx *ExecutionContext) erro
 		return errors.WithStack(err)
 	}
 
-	// We send the partial aggregation results to the shard that owns the key
-	for i, stateHolder := range holders.holders {
-		if stateHolder.aggState.IsChanged() {
-			// We ignore the first 16 bytes as this is shard-id|table-id
-			remoteShardID, err := a.sharder.CalculateShard(sharder.ShardTypeHash, stateHolder.keyBytes[16:])
-			if err != nil {
-				return errors.WithStack(err)
-			}
-
-			// The batch sequence is a uint32 that is incremented for each batch written
-			// The state holder id is generated using a sequence deterministically for each batch processed
-			// We create the sequence value for the dedup key by combining both into a uint64
-			// The main thing here is that the same dup key is generated if the same batch is processed again
-
-			seq := 0
-			// FIXME
-			dupSeq := uint64(seq)<<32 | uint64(i)
-
-			forwardKey := util.EncodeKeyForForwardAggregation(ctx.EnableDuplicateDetection, a.PartialAggTableInfo.ID,
-				ctx.WriteBatch.ShardID, dupSeq, a.FullAggTableInfo.ID)
-			value := util.EncodePrevAndCurrentRow(stateHolder.initialRowBytes, stateHolder.rowBytes)
-			ctx.AddToForwardBatch(remoteShardID, forwardKey, value)
-
-		}
-	}
-	return nil
-}
-
-// HandleRemoteRows is called when partial aggregation is forwarded from another shard
-func (a *Aggregator) HandleRemoteRows(rowsBatch RowsBatch, ctx *ExecutionContext) error {
-
-	numRows := rowsBatch.Len()
-	stateHolders := &stateHolders{holdersMap: make(map[string]*aggStateHolder)}
-	readRows := a.rowsFactory.NewRows(numRows)
-	numCols := len(a.colTypes)
-	for i := 0; i < numRows; i++ {
-		prevRow := rowsBatch.PreviousRow(i)
-		currRow := rowsBatch.CurrentRow(i)
-		if err := a.calcFullAggregation(prevRow, currRow, readRows, stateHolders, ctx.WriteBatch.ShardID, numCols); err != nil {
-			return errors.WithStack(err)
-		}
-	}
-
-	// Store the results
-	if err := a.storeAggregateResults(stateHolders, ctx.WriteBatch); err != nil {
-		return errors.WithStack(err)
-	}
-
 	resultRows := a.rowsFactory.NewRows(numRows)
 	entries := make([]RowsEntry, 0, numRows)
 	rc := 0
 
 	// Send the rows to the parent
-	for _, stateHolder := range stateHolders.holders {
+	for _, stateHolder := range holders.holders {
 		if stateHolder.aggState.IsChanged() {
 			prevRow := stateHolder.initialRow
 			currRow := stateHolder.row
@@ -159,18 +164,18 @@ func (a *Aggregator) HandleRemoteRows(rowsBatch RowsBatch, ctx *ExecutionContext
 				ci = rc
 				rc++
 			}
-			entries = append(entries, NewRowsEntry(pi, ci))
+			entries = append(entries, NewRowsEntry(pi, ci, -1))
 		}
 	}
 
 	return a.parent.HandleRows(NewRowsBatch(resultRows, entries), ctx)
 }
 
-func (a *Aggregator) calcPartialAggregations(prevRow *common.Row, currRow *common.Row, readRows *common.Rows,
+func (a *Aggregator) calcAggregations(prevRow *common.Row, currRow *common.Row, readRows *common.Rows,
 	aggStateHolders *stateHolders, shardID uint64) error {
 
 	// Create the key
-	keyBytes, err := a.createKeyFromPrevOrCurrRow(prevRow, currRow, shardID, a.GetChildren()[0].ColTypes(), a.groupByCols, a.PartialAggTableInfo.ID)
+	keyBytes, err := a.createKeyFromPrevOrCurrRow(prevRow, currRow, shardID, a.GetChildren()[0].ColTypes(), a.groupByCols, a.AggTableInfo.ID)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -195,72 +200,6 @@ func (a *Aggregator) calcPartialAggregations(prevRow *common.Row, currRow *commo
 	return nil
 }
 
-func (a *Aggregator) calcFullAggregation(prevRow *common.Row, currRow *common.Row, readRows *common.Rows,
-	stateHolders *stateHolders, shardID uint64, numCols int) error {
-
-	key, err := a.createKeyFromPrevOrCurrRow(prevRow, currRow, shardID, a.colTypes, a.keyCols, a.FullAggTableInfo.ID)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	stateHolder, err := a.loadAggregateState(key, readRows, stateHolders)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	currAggState := stateHolder.aggState
-
-	var prevMergeState *aggfuncs.AggState
-	if prevRow != nil {
-		prevMergeState = aggfuncs.NewAggState(numCols)
-		if err := a.initAggStateWithRow(prevRow, prevMergeState, numCols); err != nil {
-			return errors.WithStack(err)
-		}
-		if err := a.mergeState(prevMergeState, currAggState, true); err != nil {
-			return err
-		}
-	}
-	var currMergeState *aggfuncs.AggState
-	if currRow != nil {
-		currMergeState = aggfuncs.NewAggState(numCols)
-		if err := a.initAggStateWithRow(currRow, currMergeState, numCols); err != nil {
-			return errors.WithStack(err)
-		}
-		if err := a.mergeState(currMergeState, currAggState, false); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (a *Aggregator) mergeState(toMerge *aggfuncs.AggState, currState *aggfuncs.AggState, reverse bool) error {
-	for index, aggFunc := range a.aggFuncs {
-		switch aggFunc.ValueType().Type {
-		case common.TypeTinyInt, common.TypeInt, common.TypeBigInt:
-			if err := aggFunc.MergeInt64(toMerge, currState, index, reverse); err != nil {
-				return err
-			}
-		case common.TypeDecimal:
-			if err := aggFunc.MergeDecimal(toMerge, currState, index, reverse); err != nil {
-				return err
-			}
-		case common.TypeDouble:
-			if err := aggFunc.MergeFloat64(toMerge, currState, index, reverse); err != nil {
-				return err
-			}
-		case common.TypeVarchar:
-			if err := aggFunc.MergeString(toMerge, currState, index, reverse); err != nil {
-				return err
-			}
-		case common.TypeTimestamp:
-			if err := aggFunc.MergeTimestamp(toMerge, currState, index, reverse); err != nil {
-				return err
-			}
-		default:
-			return errors.Errorf("unexpected column type %d", aggFunc.ValueType())
-		}
-	}
-	return nil
-}
-
 func (a *Aggregator) loadAggregateState(keyBytes []byte, readRows *common.Rows, aggStateHolders *stateHolders) (*aggStateHolder, error) {
 	sKey := common.ByteSliceToStringZeroCopy(keyBytes)
 	stateHolder, ok := aggStateHolders.holdersMap[sKey] // maybe already cached for this batch
@@ -273,7 +212,7 @@ func (a *Aggregator) loadAggregateState(keyBytes []byte, readRows *common.Rows, 
 		var currRow *common.Row
 		if rowBytes != nil {
 			// Doesn't matter if we use partial or full col types here as they are the same
-			if err := common.DecodeRow(rowBytes, a.PartialAggTableInfo.ColumnTypes, readRows); err != nil {
+			if err := common.DecodeRow(rowBytes, a.AggTableInfo.ColumnTypes, readRows); err != nil {
 				return nil, errors.WithStack(err)
 			}
 			r := readRows.GetRow(readRows.RowCount() - 1)
@@ -336,7 +275,7 @@ func (a *Aggregator) storeAggregateResults(stateHolders *stateHolders, writeBatc
 			row := resultRows.GetRow(rowCount)
 			stateHolder.row = &row
 			// Doesn't matter if we use partial or full col types here as they are the same
-			valueBuff, err := common.EncodeRow(&row, a.PartialAggTableInfo.ColumnTypes, make([]byte, 0))
+			valueBuff, err := common.EncodeRow(&row, a.AggTableInfo.ColumnTypes, make([]byte, 0))
 			if err != nil {
 				return errors.WithStack(err)
 			}

--- a/push/exec/projection.go
+++ b/push/exec/projection.go
@@ -96,7 +96,7 @@ func (p *PushProjection) HandleRows(rowsBatch RowsBatch, ctx *ExecutionContext) 
 			ci = rc
 			rc++
 		}
-		entries[i] = RowsEntry{prevIndex: pi, currIndex: ci}
+		entries[i] = NewRowsEntry(pi, ci, rowsBatch.ReceiverIndex(i))
 	}
 	return p.parent.HandleRows(NewRowsBatch(result, entries), ctx)
 }

--- a/push/exec/table_exec.go
+++ b/push/exec/table_exec.go
@@ -109,6 +109,7 @@ func (t *TableExecutor) HandleRows(rowsBatch RowsBatch, ctx *ExecutionContext) e
 	for i := 0; i < numEntries; i++ {
 		prevRow := rowsBatch.PreviousRow(i)
 		currentRow := rowsBatch.CurrentRow(i)
+		receiverIndex := rowsBatch.ReceiverIndex(i)
 
 		if currentRow != nil {
 			keyBuff := table.EncodeTableKeyPrefix(t.TableInfo.ID, ctx.WriteBatch.ShardID, 32)
@@ -135,6 +136,7 @@ func (t *TableExecutor) HandleRows(rowsBatch RowsBatch, ctx *ExecutionContext) e
 			rc++
 			entries[i].prevIndex = pi
 			entries[i].currIndex = ci
+			entries[i].receiverIndex = receiverIndex
 			var valueBuff []byte
 			valueBuff, err = common.EncodeRow(currentRow, t.colTypes, valueBuff)
 			if err != nil {
@@ -151,6 +153,7 @@ func (t *TableExecutor) HandleRows(rowsBatch RowsBatch, ctx *ExecutionContext) e
 			outRows.AppendRow(*prevRow)
 			entries[i].prevIndex = rc
 			entries[i].currIndex = -1
+			entries[i].receiverIndex = receiverIndex
 			rc++
 			ctx.WriteBatch.AddDelete(keyBuff)
 		}

--- a/push/exec/table_scan.go
+++ b/push/exec/table_scan.go
@@ -10,9 +10,7 @@ import (
 type Scan struct {
 	pushExecutorBase
 	TableName string
-	//pkOnly    bool
-	//projExprs []*common.Expression
-	cols []int
+	cols      []int
 }
 
 func NewScan(tableName string, cols []int) (*Scan, error) {
@@ -106,7 +104,7 @@ func (t *Scan) HandleRows(rowsBatch RowsBatch, ctx *ExecutionContext) error {
 				ci = rc
 				rc++
 			}
-			entries[i] = NewRowsEntry(pi, ci)
+			entries[i] = NewRowsEntry(pi, ci, rowsBatch.ReceiverIndex(i))
 		}
 		return t.parent.HandleRows(NewRowsBatch(newRows, entries), ctx)
 	}

--- a/push/exec/union_all.go
+++ b/push/exec/union_all.go
@@ -81,7 +81,7 @@ func (u *UnionAll) HandleRowsWithIndex(index int, rowsBatch RowsBatch, ctx *Exec
 			ci = rc
 			rc++
 		}
-		entries[i] = NewRowsEntry(pi, ci)
+		entries[i] = NewRowsEntry(pi, ci, rowsBatch.ReceiverIndex(i))
 	}
 
 	return u.parent.HandleRows(NewRowsBatch(out, entries), ctx)

--- a/push/exec_builder.go
+++ b/push/exec_builder.go
@@ -117,17 +117,17 @@ func (m *MaterializedView) buildPushDAG(plan planner.PhysicalPlan, aggSequence i
 			pkCols[i] = i + nonFirstRowFuncs
 		}
 
-		partialTableID := seqGenerator.GenerateSequence()
-		partialTableName := fmt.Sprintf("%s-partial-aggtable-%d", mvName, aggSequence)
-		aggSequence++
-		partialTableInfo := &common.TableInfo{
-			ID:             partialTableID,
-			SchemaName:     schema.Name,
-			Name:           partialTableName,
-			PrimaryKeyCols: pkCols,
-			IndexInfos:     nil, // TODO
-			Internal:       true,
-		}
+		//partialTableID := seqGenerator.GenerateSequence()
+		//partialTableName := fmt.Sprintf("%s-partial-aggtable-%d", mvName, aggSequence)
+		//aggSequence++
+		//partialTableInfo := &common.TableInfo{
+		//	ID:             partialTableID,
+		//	SchemaName:     schema.Name,
+		//	Name:           partialTableName,
+		//	PrimaryKeyCols: pkCols,
+		//	IndexInfos:     nil, // TODO
+		//	Internal:       true,
+		//}
 		fullTableID := seqGenerator.GenerateSequence()
 		fullTableName := fmt.Sprintf("%s-full-aggtable-%d", mvName, aggSequence)
 		aggSequence++
@@ -139,17 +139,17 @@ func (m *MaterializedView) buildPushDAG(plan planner.PhysicalPlan, aggSequence i
 			IndexInfos:     nil, // TODO
 			Internal:       true,
 		}
-		partialAggInfo := &common.InternalTableInfo{
-			TableInfo:            partialTableInfo,
-			MaterializedViewName: mvName,
-		}
-		internalTables = append(internalTables, partialAggInfo)
+		//partialAggInfo := &common.InternalTableInfo{
+		//	TableInfo:            partialTableInfo,
+		//	MaterializedViewName: mvName,
+		//}
+		//internalTables = append(internalTables, partialAggInfo)
 		fullAggInfo := &common.InternalTableInfo{
 			TableInfo:            fullTableInfo,
 			MaterializedViewName: mvName,
 		}
 		internalTables = append(internalTables, fullAggInfo)
-		executor, err = exec.NewAggregator(pkCols, aggFuncs, partialTableInfo, fullTableInfo, groupByCols, m.cluster, m.sharder)
+		executor, err = exec.NewAggregator(pkCols, aggFuncs, fullTableInfo, groupByCols, m.cluster, m.sharder)
 		if err != nil {
 			return nil, nil, errors.WithStack(err)
 		}

--- a/push/mv.go
+++ b/push/mv.go
@@ -107,17 +107,17 @@ func (m *MaterializedView) disconnectOrDeleteDataForMV(schema *common.Schema, no
 		}
 	case *exec.Aggregator:
 		if disconnect {
-			err := m.pe.UnregisterRemoteConsumer(op.FullAggTableInfo.ID)
+			err := m.pe.UnregisterRemoteConsumer(op.AggTableInfo.ID)
 			if err != nil {
 				return errors.WithStack(err)
 			}
 		}
 		if deleteData {
-			err := m.deleteTableData(op.PartialAggTableInfo.ID)
+			err := m.deleteTableData(op.AggTableInfo.ID)
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			err = m.deleteTableData(op.FullAggTableInfo.ID)
+			err = m.deleteTableData(op.AggTableInfo.ID)
 			if err != nil {
 				return errors.WithStack(err)
 			}
@@ -185,14 +185,14 @@ func (m *MaterializedView) connect(executor exec.PushExecutor, addConsuming bool
 		}
 	case *exec.Aggregator:
 		if registerRemote {
-			colTypes := op.FullAggTableInfo.ColumnTypes
+			colTypes := op.GetChildren()[0].ColTypes()
 			rf := common.NewRowsFactory(colTypes)
 			rc := &RemoteConsumer{
 				RowsFactory: rf,
 				ColTypes:    colTypes,
 				RowsHandler: op,
 			}
-			err := m.pe.RegisterRemoteConsumer(op.FullAggTableInfo.ID, rc)
+			err := m.pe.RegisterRemoteConsumer(op.AggTableInfo.ID, rc)
 			if err != nil {
 				return errors.WithStack(err)
 			}

--- a/push/util/util.go
+++ b/push/util/util.go
@@ -41,7 +41,6 @@ func EncodeKeyForForwardAggregation(enableDupDetection bool, partialAggTableID u
 	sequence uint64, remoteConsumerID uint64) []byte {
 
 	buff := make([]byte, 0, 33)
-
 	// First byte is whether duplicate detection is enabled or not
 	if enableDupDetection {
 		buff = append(buff, 1)

--- a/sqltest/sql_test_runner.go
+++ b/sqltest/sql_test_runner.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	TestPrefix           = "" // Set this to the name of a test if you want to only run that test, e.g. during development
-	ExcludedTestPrefixes = "redelivery_prana_restart,aggregation_forward_failure"
+	ExcludedTestPrefixes = ""
 	TestClusterID        = 12345678
 	ProtoDescriptorDir   = "../protos"
 )


### PR DESCRIPTION
The previous PR improved row processing logic but broke duplicate detection. The batch sequence based duplicate detection was needed for dup detection of forwarding partial aggregations. In order to get this to work for forward aggregations it was essential that the exact same batch of rows was reprocessed before the resulting aggregation was resent after failure, otherwise consistency would be lost. So we passed the batch sequence. But this meant batches had to be small and thus throughput was affected.
On close inspection it was also realised that the concept of partial aggregations was broken in the general case - while they might work for some simple aggregate functions, they don't work in general as it's not always possible to compute the result of an aggregation given N partial aggregations (e.g. you can't compute AVG this way based on two other averages). Moreover it's not possible to implement reversals of aggregations given partial aggregations, in general. And we will need to implement those at some point.
So this PR removes partial aggregations, and we now forward rows to the owning shard for aggregation. This means we can use ReceiverSequence for the dedup sequence and re-enable duplicate detection.