### PR TITLE
Make sure ddl clients have health checker on them

### DIFF
--- a/sqltest/sql_test_runner.go
+++ b/sqltest/sql_test_runner.go
@@ -197,6 +197,7 @@ func (w *sqlTestsuite) setupPranaCluster() {
 			cnf.ScreenDragonLogSpam = true
 			cnf.DisableShardPlacementSanityCheck = true
 			cnf.RaftRTTMs = 25
+			cnf.RaftHeartbeatRTT = 15
 			s, err := server.NewServer(*cnf)
 			if err != nil {
 				log.Fatal(err)


### PR DESCRIPTION
The main ddl client and the reset client didn't have the health checker attached, so if nodes went down then came up again, they weren't broadcasting to the new nodes.