### PR TITLE
For ddl and reset client always try to connect to nodes

### DIFF
--- a/cluster/dragon/dragon.go
+++ b/cluster/dragon/dragon.go
@@ -1064,7 +1064,7 @@ func (d *Dragon) getOrCreateRequestClient(shardID uint64) (remoting.Client, erro
 		return cl, nil
 	}
 	serverAddresses := d.getServerAddressesForShard(shardID)
-	cl = remoting.NewClient(serverAddresses...)
+	cl = remoting.NewClient(false, serverAddresses...)
 	if err := cl.Start(); err != nil {
 		return nil, err
 	}

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -14,7 +14,7 @@ const (
 	DefaultSequenceCompactionOverhead  = 250
 	DefaultLocksSnapshotEntries        = 1000
 	DefaultLocksCompactionOverhead     = 250
-	DefaultRemotingHeartbeatInterval   = 10 * time.Second
+	DefaultRemotingHeartbeatInterval   = 5 * time.Second
 	DefaultRemotingHeartbeatTimeout    = 5 * time.Second
 	DefaultGlobalIngestLimitRowsPerSec = 1000
 	DefaultRaftRTTMs                   = 50

--- a/push/lag_manager.go
+++ b/push/lag_manager.go
@@ -21,7 +21,7 @@ type LagManager struct {
 var _ util.LagProvider = &LagManager{}
 
 func NewLagManager(engine *Engine, notifAddresses ...string) *LagManager {
-	broadcastClient := remoting.NewClient(notifAddresses...)
+	broadcastClient := remoting.NewClient(false, notifAddresses...)
 	return &LagManager{broadcastClient: broadcastClient, engine: engine}
 }
 

--- a/remoting/remoting_test.go
+++ b/remoting/remoting_test.go
@@ -70,7 +70,7 @@ func TestNotificationStopServer(t *testing.T) {
 	for _, server := range servers {
 		listenAddresses = append(listenAddresses, server.ListenAddress())
 	}
-	client := newClient(listenAddresses...)
+	client := newClient(false, listenAddresses...)
 	err := client.Start()
 	require.NoError(t, err)
 	defer stopClient(t, client)
@@ -114,7 +114,7 @@ func TestNotificationsMultipleConnections(t *testing.T) {
 	clients := make([]*client, 10)
 
 	for i := 0; i < numClients; i++ {
-		client := newClient(listenAddresses...)
+		client := newClient(false, listenAddresses...)
 		err := client.Start()
 		require.NoError(t, err)
 		clients[i] = client
@@ -160,7 +160,7 @@ func testNotifications(t *testing.T, numServers int, notifsToSend ...string) ([]
 		listenAddresses = append(listenAddresses, server.ListenAddress())
 	}
 
-	client := newClient(listenAddresses...)
+	client := newClient(false, listenAddresses...)
 	err := client.Start()
 	require.NoError(t, err)
 	defer stopClient(t, client)
@@ -194,7 +194,7 @@ func TestMultipleNotificationTypes(t *testing.T) {
 	err := server.Start()
 	require.NoError(t, err)
 
-	client := newClient("localhost:7888")
+	client := newClient(false, "localhost:7888")
 	err = client.Start()
 	require.NoError(t, err)
 	defer stopClient(t, client)
@@ -236,7 +236,7 @@ func TestSyncBroadcast(t *testing.T) {
 		listenAddresses = append(listenAddresses, server.ListenAddress())
 	}
 
-	client := newClient(listenAddresses...)
+	client := newClient(false, listenAddresses...)
 	err := client.Start()
 	require.NoError(t, err)
 	defer stopClient(t, client)
@@ -276,7 +276,7 @@ func TestSyncBroadcastWithFailingNotif(t *testing.T) {
 		listenAddresses = append(listenAddresses, server.ListenAddress())
 	}
 
-	client := newClient(listenAddresses...)
+	client := newClient(false, listenAddresses...)
 	err := client.Start()
 	require.NoError(t, err)
 	defer stopClient(t, client)
@@ -335,7 +335,7 @@ func TestSendRequest(t *testing.T) {
 	err := server.Start()
 	require.NoError(t, err)
 
-	client := newClient("localhost:7888")
+	client := newClient(false, "localhost:7888")
 	err = client.Start()
 	require.NoError(t, err)
 	defer stopClient(t, client)
@@ -370,7 +370,7 @@ func TestSendMultipleRequests(t *testing.T) {
 	err := server.Start()
 	require.NoError(t, err)
 
-	client := newClient("localhost:7888")
+	client := newClient(false, "localhost:7888")
 	err = client.Start()
 	require.NoError(t, err)
 	defer stopClient(t, client)
@@ -408,7 +408,7 @@ func TestSendMultipleRequests(t *testing.T) {
 func TestSendRequestServerNotAvailable(t *testing.T) {
 	t.Helper()
 
-	client := newClient("localhost:7888")
+	client := newClient(false, "localhost:7888")
 	err := client.Start()
 	require.NoError(t, err)
 	defer stopClient(t, client)
@@ -446,7 +446,7 @@ func TestSendRequestOneServerNotAvailable(t *testing.T) {
 	err := server.Start()
 	require.NoError(t, err)
 
-	client := newClient("localhost:7889", "localhost:7888")
+	client := newClient(false, "localhost:7889", "localhost:7888")
 	err = client.Start()
 	require.NoError(t, err)
 	defer stopClient(t, client)
@@ -483,7 +483,7 @@ func TestSendRequestWithError(t *testing.T) {
 	err := server.Start()
 	require.NoError(t, err)
 
-	client := newClient("localhost:7888")
+	client := newClient(false, "localhost:7888")
 	err = client.Start()
 	require.NoError(t, err)
 	defer stopClient(t, client)

--- a/sqltest/testdata/aggregation_forward_failure_test_out.txt
+++ b/sqltest/testdata/aggregation_forward_failure_test_out.txt
@@ -70,6 +70,8 @@ select * from test_mv_1;
 
 --wait for schedulers;
 
+--pause 2000;
+
 -- state should be resolved;
 
 use test;

--- a/sqltest/testdata/aggregation_forward_failure_test_script.txt
+++ b/sqltest/testdata/aggregation_forward_failure_test_script.txt
@@ -59,6 +59,8 @@ select * from test_mv_1;
 
 --wait for schedulers;
 
+--pause 2000;
+
 -- state should be resolved;
 
 use test;


### PR DESCRIPTION
This fixes a bug where if a node was shutdown then came back up again, the ddl and ddl reset clients wouldn't attempt to broadcast ddl to that node.