### PR TITLE
Make sure we apply config defaults correctly

### DIFF
--- a/cmd/pranadb/main.go
+++ b/cmd/pranadb/main.go
@@ -53,8 +53,6 @@ func (r *runner) run(args []string, start bool) error {
 		}
 	}
 	cfg := arguments{}
-	defaults := conf.NewDefaultConfig()
-	cfg.Server = *defaults
 	parser, err := kong.New(&cfg, kong.Configuration(konghcl.Loader))
 	if err != nil {
 		return errors.WithStack(err)
@@ -66,7 +64,7 @@ func (r *runner) run(args []string, start bool) error {
 	if err := cfg.Log.Configure(); err != nil {
 		return errors.WithStack(err)
 	}
-
+	cfg.Server.ApplyDefaults()
 	s, err := server.NewServer(cfg.Server)
 	if err != nil {
 		return errors.WithStack(err)

--- a/cmd/pranadb/runner_test.go
+++ b/cmd/pranadb/runner_test.go
@@ -87,5 +87,8 @@ func createConfigWithAllFields() conf.Config {
 		RaftRTTMs:                   100,
 		RaftElectionRTT:             300,
 		RaftHeartbeatRTT:            30,
+		ProcessorMaxLag:             6500 * time.Millisecond,
+		FillMaxLag:                  12000 * time.Millisecond,
+		SourceLagTimeout:            65000 * time.Millisecond,
 	}
 }

--- a/cmd/pranadb/testdata/config.hcl
+++ b/cmd/pranadb/testdata/config.hcl
@@ -58,3 +58,6 @@ global-ingest-limit-rows-per-sec = 5000
 raft-rtt-ms                       = 100
 raft-heartbeat-rtt                = 30
 raft-election-rtt                 = 300
+processor-max-lag                 = "6500ms"
+fill-max-lag                      = "12000ms"
+source-lag-timeout                = "65000ms"

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -8,12 +8,12 @@ import (
 )
 
 const (
-	DefaultDataSnapshotEntries         = 10000
-	DefaultDataCompactionOverhead      = 2500
+	DefaultDataSnapshotEntries         = 50000
+	DefaultDataCompactionOverhead      = 5000
 	DefaultSequenceSnapshotEntries     = 1000
-	DefaultSequenceCompactionOverhead  = 250
+	DefaultSequenceCompactionOverhead  = 50
 	DefaultLocksSnapshotEntries        = 1000
-	DefaultLocksCompactionOverhead     = 250
+	DefaultLocksCompactionOverhead     = 50
 	DefaultRemotingHeartbeatInterval   = 5 * time.Second
 	DefaultRemotingHeartbeatTimeout    = 5 * time.Second
 	DefaultGlobalIngestLimitRowsPerSec = 1000
@@ -64,6 +64,54 @@ type Config struct {
 	ProcessorMaxLag                  time.Duration
 	FillMaxLag                       time.Duration
 	SourceLagTimeout                 time.Duration
+}
+
+func (c *Config) ApplyDefaults() {
+	if c.DataSnapshotEntries == 0 {
+		c.DataSnapshotEntries = DefaultDataSnapshotEntries
+	}
+	if c.DataCompactionOverhead == 0 {
+		c.DataCompactionOverhead = DefaultDataCompactionOverhead
+	}
+	if c.SequenceSnapshotEntries == 0 {
+		c.SequenceSnapshotEntries = DefaultSequenceSnapshotEntries
+	}
+	if c.SequenceCompactionOverhead == 0 {
+		c.SequenceCompactionOverhead = DefaultSequenceCompactionOverhead
+	}
+	if c.LocksSnapshotEntries == 0 {
+		c.LocksSnapshotEntries = DefaultLocksSnapshotEntries
+	}
+	if c.LocksCompactionOverhead == 0 {
+		c.LocksCompactionOverhead = DefaultLocksCompactionOverhead
+	}
+	if c.RemotingHeartbeatInterval == 0 {
+		c.RemotingHeartbeatInterval = DefaultRemotingHeartbeatInterval
+	}
+	if c.RemotingHeartbeatTimeout == 0 {
+		c.RemotingHeartbeatTimeout = DefaultRemotingHeartbeatTimeout
+	}
+	if c.GlobalIngestLimitRowsPerSec == 0 {
+		c.GlobalIngestLimitRowsPerSec = DefaultGlobalIngestLimitRowsPerSec
+	}
+	if c.RaftRTTMs == 0 {
+		c.RaftRTTMs = DefaultRaftRTTMs
+	}
+	if c.RaftHeartbeatRTT == 0 {
+		c.RaftHeartbeatRTT = DefaultRaftHeartbeatRTT
+	}
+	if c.RaftElectionRTT == 0 {
+		c.RaftElectionRTT = DefaultRaftElectionRTT
+	}
+	if c.ProcessorMaxLag == 0 {
+		c.ProcessorMaxLag = DefaultProcessorMaxLag
+	}
+	if c.FillMaxLag == 0 {
+		c.FillMaxLag = DefaultFillMaxLag
+	}
+	if c.SourceLagTimeout == 0 {
+		c.SourceLagTimeout = DefaultSourceLagTimeout
+	}
 }
 
 func (c *Config) Validate() error { //nolint:gocyclo

--- a/push/lag_manager.go
+++ b/push/lag_manager.go
@@ -1,10 +1,12 @@
 package push
 
 import (
+	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/squareup/pranadb/protos/squareup/cash/pranadb/v1/notifications"
 	"github.com/squareup/pranadb/push/util"
 	"github.com/squareup/pranadb/remoting"
+	"strings"
 	"sync"
 	"time"
 )
@@ -97,6 +99,12 @@ func (lm *LagManager) broadcastLags() {
 func (lm *LagManager) broadcastLagsNoLock() {
 	lm.lagsTimer = time.AfterFunc(1*time.Second, func() {
 		msg := lm.engine.getLagsMessage()
+		sb := strings.Builder{}
+		sb.WriteString("lags are: ")
+		for _, entry := range msg.Lags {
+			sb.WriteString(fmt.Sprintf("shard_id:%d lag:%d ms ", entry.ShardId, time.Duration(entry.Lag).Milliseconds()))
+		}
+		log.Debug(sb.String())
 		if err := lm.broadcastClient.BroadcastOneway(msg); err != nil {
 			log.Errorf("failed to broadcast lags %+v", err)
 		} else {

--- a/push/util/util.go
+++ b/push/util/util.go
@@ -116,7 +116,7 @@ func MaybeThrottleIfLagging(allShards []uint64, lagProvider LagProvider, accepta
 		}
 		time.Sleep(10 * time.Millisecond)
 		if time.Now().Sub(st) > timeout {
-			log.Warn("timed out in waiting for acceptable lags")
+			log.Warnf("timed out in waiting for acceptable lags, timeout is %d acceptable lag is %d", timeout, acceptableLag)
 			return false
 		}
 	}

--- a/storage.yaml
+++ b/storage.yaml
@@ -1,0 +1,9 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: ebs-io2
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  type: io2
+  iopsPerGB: "200"


### PR DESCRIPTION
Previously we weren't applying config defaults correctly resulting in zero values for acceptable lag etc.

Now we apply defaults in main. 

This PR also changes defaults for snapshot entries, and adds logging for lags