### PR TITLE
Datadog message field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ vendor
 .hermit/
 kafkaserver/
 prana-data/
+*.log

--- a/cfg/example_5nodes.conf
+++ b/cfg/example_5nodes.conf
@@ -1,0 +1,69 @@
+// Example Prana server configuration file
+// Please note that NodeID is not specified in the config file, it is specified on the command line. This allows you to use
+// the same config file for each node in the cluster
+
+cluster-id = 1 // Each node in the same Prana cluster must have the same ClusterID, there can be multiple Prana clusters on your network
+
+// RaftAddresses are the addresses used by Dragonboat to form Raft clusters. They can be local to your network
+raft-addresses = [
+  "localhost:63201",
+  "localhost:63202",
+  "localhost:63203",
+  "localhost:63204",
+  "localhost:63205"
+]
+
+// Each node of the cluster listens for notifications from other nodes - these are the addresses they listen at. They can be local to your network
+notif-listen-addresses = [
+  "localhost:63301",
+  "localhost:63302",
+  "localhost:63303",
+  "localhost:63304",
+  "localhost:63305"
+]
+
+// These are the addresses the API server listens at on each node - these is used for connecting from clients. They need to be accessible from the client.
+api-server-listen-addresses = [
+  "localhost:6584",
+  "localhost:6585",
+  "localhost:6586",
+  "localhost:6587",
+  "localhost:6588"
+]
+
+num-shards         = 50 // The total number of shards in the cluster
+replication-factor = 3 // The number of replicas - each write will be replicated to this many replicas
+data-dir           = "prana-data" // The base directory for storing data
+
+// KafkaBrokers are the config for the Kafka brokers used by Prana
+// - a map of broker name (a string) to the broker config
+kafka-brokers = {
+  testbroker = {
+    client-type = 2, // Client type determines which Kafka client library is used
+    properties  = {
+      // Properties get passed through to the client library
+      "bootstrap.servers": "localhost:9092"
+    }
+  }
+}
+
+// Logging config
+log-level = "trace"
+log-format = "json"
+
+// It is less likely you will want to change these settings
+
+test-server                       = false // For a real server always set to false
+data-snapshot-entries             = 10000 // The number of data writes before a snapshot is triggered
+data-compaction-overhead          = 2500 // After a snapshot is taken how many writes to retain for main data
+sequence-snapshot-entries         = 1000 // The number of sequence writes before a snapshot is triggered
+sequence-compaction-overhead      = 250 // After a snapshot is taken how many writes to retain for sequences
+locks-snapshot-entries            = 1000 // The number of lock writes before a snapshot is triggered
+locks-compaction-overhead         = 250 // After a snapshot is taken how many writes to retain for locks
+remoting-heartbeat-interval       = "10s" // Amount of time between remoting heartbeats
+remoting-heartbeat-timeout        = "5s" // Timeout for a remoting heartbeat
+enable-api-server                 = true // Set to true to enable the API server - needed for CLI access
+global-ingest-limit-rows-per-sec  = 10000 // The maximum number of rows per second that can be ingested in the broker - ingest will be throttled to this rate. -1 represents no throttling
+raft-rtt-ms                       = 50 // The size of a Raft RTT unit in ms
+raft-heartbeat-rtt                = 30 // The Raft heartbeat period in units of raft-rtt-ms
+raft-election-rtt                 = 300 // The Raft election period in units of raft-rtt-ms

--- a/cluster/dragon/logadaptor/logrus_adaptor.go
+++ b/cluster/dragon/logadaptor/logrus_adaptor.go
@@ -26,30 +26,34 @@ func (l *LogrusILogger) SetLevel(level logger.LogLevel) {
 	atomic.StoreInt64(&l.level, int64(level))
 }
 
+func addPrefix(str string) string {
+	return "dragon: " + str
+}
+
 func (l *LogrusILogger) Debugf(format string, args ...interface{}) {
 	if l.getLevel() >= logger.DEBUG {
-		log.Debugf(format, args...)
+		log.Debugf(addPrefix(format), args...)
 	}
 }
 
 func (l *LogrusILogger) Infof(format string, args ...interface{}) {
 	if l.getLevel() >= logger.INFO {
-		log.Infof(format, args...)
+		log.Infof(addPrefix(format), args...)
 	}
 }
 
 func (l *LogrusILogger) Warningf(format string, args ...interface{}) {
 	if l.getLevel() >= logger.WARNING {
-		log.Warnf(format, args...)
+		log.Warnf(addPrefix(format), args...)
 	}
 }
 
 func (l *LogrusILogger) Errorf(format string, args ...interface{}) {
 	if l.getLevel() >= logger.ERROR {
-		log.Errorf(format, args...)
+		log.Errorf(addPrefix(format), args...)
 	}
 }
 
 func (l *LogrusILogger) Panicf(format string, args ...interface{}) {
-	log.Fatalf(format, args...)
+	log.Fatalf(addPrefix(format), args...)
 }

--- a/log/log.go
+++ b/log/log.go
@@ -1,10 +1,10 @@
 package log
 
 import (
+	"github.com/squareup/pranadb/errors"
 	"os"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/squareup/pranadb/errors"
 )
 
 // Config contains the configuration for the global logger.
@@ -36,7 +36,13 @@ func (cfg *Config) Configure() error {
 	case "text":
 		log.SetFormatter(&log.TextFormatter{TimestampFormat: TimestampFormat, FullTimestamp: true})
 	case "json":
-		log.SetFormatter(&log.JSONFormatter{TimestampFormat: TimestampFormat})
+		formatter := &log.JSONFormatter{
+			TimestampFormat: TimestampFormat,
+			FieldMap: log.FieldMap{
+				log.FieldKeyMsg: "message",
+			},
+		}
+		log.SetFormatter(formatter)
 	default:
 		return errors.NewInvalidConfigurationError("log format must be either text or json")
 	}


### PR DESCRIPTION
Datadog requires to log our log messages under a "message" field for them to be searchable. By default logrus uses "msg"

Also added a 5 node config, and prefix dragon logs with "dragon" for easier filtering.