### PR TITLE
Make sure we retry dead cached remoting connections and enable TCP keepalive

### DIFF
--- a/remoting/connection.go
+++ b/remoting/connection.go
@@ -83,7 +83,7 @@ func (c *clientConnection) start() {
 	})
 }
 
-func (c *clientConnection) Stop() {
+func (c *clientConnection) Close() {
 	c.lock.Lock()
 	c.closed = true
 	c.lock.Unlock() // Note, we must unlock before closing the connection to avoid deadlock
@@ -132,8 +132,10 @@ func createNetConnection(serverAddress string) (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = nc.SetNoDelay(true)
-	if err != nil {
+	if err = nc.SetNoDelay(true); err != nil {
+		return nil, err
+	}
+	if err = nc.SetKeepAlive(true); err != nil {
 		return nil, err
 	}
 	return nc, nil

--- a/remoting/connection_test.go
+++ b/remoting/connection_test.go
@@ -32,7 +32,7 @@ func TestSendRequest(t *testing.T) {
 	require.Equal(t, "badgers", resp.SomeField)
 	require.Equal(t, 1, list.getCalledCount())
 
-	conn.Stop()
+	conn.Close()
 }
 
 func TestSendConcurrentRequests(t *testing.T) {
@@ -62,7 +62,7 @@ func TestSendConcurrentRequests(t *testing.T) {
 	}
 	require.Equal(t, numRequests, list.getCalledCount())
 
-	conn.Stop()
+	conn.Close()
 }
 
 func TestResponseInternalError(t *testing.T) {
@@ -109,7 +109,7 @@ func testResponseError(t *testing.T, respErr error, checkFunc func(*testing.T, e
 
 	checkFunc(t, perr)
 
-	conn.Stop()
+	conn.Close()
 }
 
 func TestConnectFailedNoServer(t *testing.T) {
@@ -137,7 +137,7 @@ func TestCloseConnectionFromServer(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, ErrConnectionClosed, err)
 
-	conn.Stop()
+	conn.Close()
 }
 
 func TestUseOfClosedConnection(t *testing.T) {
@@ -147,7 +147,7 @@ func TestUseOfClosedConnection(t *testing.T) {
 	conn, err := createConnection(defaultServerAddress)
 	require.NoError(t, err)
 
-	conn.Stop()
+	conn.Close()
 
 	handler := newRespHandler()
 	err = conn.SendRequestAsync(&clustermsgs.RemotingTestMessage{SomeField: "badgers"}, handler)
@@ -183,7 +183,7 @@ func TestUnblockInProgressRequests(t *testing.T) {
 	}
 	serverListener.unlock()
 
-	conn.Stop()
+	conn.Close()
 }
 
 func startServerWithListener(t *testing.T, listener ClusterMessageHandler) *server {


### PR DESCRIPTION
Previously remoting connections could be closed (e.g. by firewall, nats or TCP keep alive timeout), but remain in the cache and then next time we went to use it the send failed.

Now, we attempt one time to recreate and retry dead connections, and also I've enabled TCP keep alive on the connection.