### PR TITLE
Adds an LRU cache on aggregator

### DIFF
--- a/aggfuncs/aggstate.go
+++ b/aggfuncs/aggstate.go
@@ -149,3 +149,7 @@ func (as *AggState) IsSet(index int) bool {
 func (as *AggState) IsChanged() bool {
 	return as.changed
 }
+
+func (as *AggState) SetUnchanged() {
+	as.changed = false
+}

--- a/cmd/pranadb/runner_test.go
+++ b/cmd/pranadb/runner_test.go
@@ -83,6 +83,7 @@ func createConfigWithAllFields() conf.Config {
 		RaftElectionRTT:            300,
 		RaftHeartbeatRTT:           30,
 		DisableFsync:               true,
+		AggregationCacheSizeRows:   1234,
 
 		DDProfilerTypes:           "HEAP,CPU",
 		DDProfilerServiceName:     "my-service",

--- a/cmd/pranadb/testdata/config.hcl
+++ b/cmd/pranadb/testdata/config.hcl
@@ -56,6 +56,7 @@ raft-rtt-ms                       = 100
 raft-heartbeat-rtt                = 30
 raft-election-rtt                 = 300
 disable-fsync                     = true
+aggregation-cache-size-rows       = 1234
 
 dd-profiler-types                 = "HEAP,CPU"
 dd-profiler-service-name          = "my-service"

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -15,6 +15,7 @@ const (
 	DefaultRaftRTTMs                  = 50
 	DefaultRaftHeartbeatRTT           = 30
 	DefaultRaftElectionRTT            = 300
+	DefaultAggregationCacheSizeRows   = 20000
 )
 
 type Config struct {
@@ -57,6 +58,7 @@ type Config struct {
 	DDProfilerServiceName            string
 	DDProfilerEnvironmentName        string
 	DDProfilerVersionName            string
+	AggregationCacheSizeRows         int // The maximum number of rows for an aggregation to cache in memory
 }
 
 func (c *Config) ApplyDefaults() {
@@ -86,6 +88,9 @@ func (c *Config) ApplyDefaults() {
 	}
 	if c.RaftElectionRTT == 0 {
 		c.RaftElectionRTT = DefaultRaftElectionRTT
+	}
+	if c.AggregationCacheSizeRows == 0 {
+		c.AggregationCacheSizeRows = DefaultAggregationCacheSizeRows
 	}
 }
 
@@ -216,17 +221,19 @@ func NewDefaultConfig() *Config {
 		RaftRTTMs:                  DefaultRaftRTTMs,
 		RaftHeartbeatRTT:           DefaultRaftHeartbeatRTT,
 		RaftElectionRTT:            DefaultRaftElectionRTT,
+		AggregationCacheSizeRows:   DefaultAggregationCacheSizeRows,
 	}
 }
 
 func NewTestConfig(fakeKafkaID int64) *Config {
 	return &Config{
-		RaftRTTMs:        DefaultRaftRTTMs,
-		RaftHeartbeatRTT: DefaultRaftHeartbeatRTT,
-		RaftElectionRTT:  DefaultRaftElectionRTT,
-		NodeID:           0,
-		NumShards:        10,
-		TestServer:       true,
+		RaftRTTMs:                DefaultRaftRTTMs,
+		RaftHeartbeatRTT:         DefaultRaftHeartbeatRTT,
+		RaftElectionRTT:          DefaultRaftElectionRTT,
+		AggregationCacheSizeRows: DefaultAggregationCacheSizeRows,
+		NodeID:                   0,
+		NumShards:                10,
+		TestServer:               true,
 		KafkaBrokers: BrokerConfigs{
 			"testbroker": BrokerConfig{
 				ClientType: BrokerClientFake,

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/google/btree v1.0.0
 	github.com/google/uuid v1.3.0
 	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/lib/pq v1.10.4 // indirect
 	github.com/lni/dragonboat/v3 v3.3.5
 	github.com/myesui/uuid v1.0.0 // indirect

--- a/push/exec/aggregator.go
+++ b/push/exec/aggregator.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"fmt"
+	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/squareup/pranadb/aggfuncs"
 	"github.com/squareup/pranadb/cluster"
 	"github.com/squareup/pranadb/common"
@@ -9,6 +10,7 @@ import (
 	"github.com/squareup/pranadb/push/util"
 	"github.com/squareup/pranadb/sharder"
 	"github.com/squareup/pranadb/table"
+	"sync"
 )
 
 type Aggregator struct {
@@ -19,6 +21,9 @@ type Aggregator struct {
 	storage      cluster.Cluster
 	sharder      *sharder.Sharder
 	soloAggShard int64
+	keyCaches    sync.Map
+	cachesLock   sync.Mutex
+	lruCacheSize int
 }
 
 type AggregateFunctionInfo struct {
@@ -29,16 +34,14 @@ type AggregateFunctionInfo struct {
 }
 
 type aggStateHolder struct {
-	aggState        *aggfuncs.AggState
-	initialRowBytes []byte
-	keyBytes        []byte
-	rowBytes        []byte
-	initialRow      *common.Row
-	row             *common.Row
+	aggState   *aggfuncs.AggState
+	keyBytes   []byte
+	initialRow *common.Row
+	row        *common.Row
 }
 
 func NewAggregator(pkCols []int, aggFunctions []*AggregateFunctionInfo, aggTableInfo *common.TableInfo,
-	groupByCols []int, storage cluster.Cluster, shrdr *sharder.Sharder) (*Aggregator, error) {
+	groupByCols []int, storage cluster.Cluster, shrdr *sharder.Sharder, lruCacheSize int) (*Aggregator, error) {
 
 	colTypes := make([]common.ColumnType, len(aggFunctions))
 	for i, aggFunc := range aggFunctions {
@@ -78,12 +81,12 @@ func NewAggregator(pkCols []int, aggFunctions []*AggregateFunctionInfo, aggTable
 		storage:          storage,
 		sharder:          shrdr,
 		soloAggShard:     soloAggShard,
+		lruCacheSize:     lruCacheSize,
 	}, nil
 }
 
 type stateHolders struct {
 	holdersMap map[string]*aggStateHolder
-	holders    []*aggStateHolder
 }
 
 func (a *Aggregator) HandleRows(rowsBatch RowsBatch, ctx *ExecutionContext) error {
@@ -157,6 +160,16 @@ func (a *Aggregator) HandleRows(rowsBatch RowsBatch, ctx *ExecutionContext) erro
 // HandleRemoteRows is called when partial aggregation is forwarded from another shard
 func (a *Aggregator) HandleRemoteRows(rowsBatch RowsBatch, ctx *ExecutionContext) error {
 
+	// For each shard and aggregator we maintain a small cache that holds recently accessed rows from the aggregation
+	// this helps in the case the aggregation has a reasonably small number of rows (a common case) as it means we
+	// don't have to load the current row every time from storage before we recalculate the aggregation
+	// This cache is different from the holders map which caches every aggregate row but is scoped to the current batch
+	// The lru cache is not guaranteed to hold every row in the batch
+	keyCache, err := a.getCacheForShard(ctx.WriteBatch.ShardID)
+	if err != nil {
+		return err
+	}
+
 	// Calculate the aggregations
 	holders := &stateHolders{holdersMap: make(map[string]*aggStateHolder)}
 	numRows := rowsBatch.Len()
@@ -164,7 +177,7 @@ func (a *Aggregator) HandleRemoteRows(rowsBatch RowsBatch, ctx *ExecutionContext
 	for i := 0; i < numRows; i++ {
 		prevRow := rowsBatch.PreviousRow(i)
 		currentRow := rowsBatch.CurrentRow(i)
-		if err := a.calcAggregations(prevRow, currentRow, readRows, holders, ctx.WriteBatch.ShardID); err != nil {
+		if err := a.calcAggregations(prevRow, currentRow, readRows, holders, ctx.WriteBatch.ShardID, keyCache); err != nil {
 			return err
 		}
 	}
@@ -179,7 +192,7 @@ func (a *Aggregator) HandleRemoteRows(rowsBatch RowsBatch, ctx *ExecutionContext
 	rc := 0
 
 	// Send the rows to the parent
-	for _, stateHolder := range holders.holders {
+	for _, stateHolder := range holders.holdersMap {
 		if stateHolder.aggState.IsChanged() {
 			prevRow := stateHolder.initialRow
 			currRow := stateHolder.row
@@ -196,6 +209,9 @@ func (a *Aggregator) HandleRemoteRows(rowsBatch RowsBatch, ctx *ExecutionContext
 				rc++
 			}
 			entries = append(entries, NewRowsEntry(pi, ci, -1))
+			// And put it in the lru cache
+			sKey := common.ByteSliceToStringZeroCopy(stateHolder.keyBytes)
+			keyCache.Add(sKey, stateHolder)
 		}
 	}
 
@@ -203,7 +219,7 @@ func (a *Aggregator) HandleRemoteRows(rowsBatch RowsBatch, ctx *ExecutionContext
 }
 
 func (a *Aggregator) calcAggregations(prevRow *common.Row, currRow *common.Row, readRows *common.Rows,
-	aggStateHolders *stateHolders, shardID uint64) error {
+	aggStateHolders *stateHolders, shardID uint64, keyCache *simplelru.LRU) error {
 
 	// Create the key
 	keyBytes, err := a.createKeyFromPrevOrCurrRow(prevRow, currRow, shardID, a.GetChildren()[0].ColTypes(), a.groupByCols, a.AggTableInfo.ID)
@@ -212,7 +228,7 @@ func (a *Aggregator) calcAggregations(prevRow *common.Row, currRow *common.Row, 
 	}
 
 	// Lookup existing aggregate state
-	stateHolder, err := a.loadAggregateState(shardID, keyBytes, readRows, aggStateHolders)
+	stateHolder, err := a.loadAggregateState(shardID, keyBytes, readRows, aggStateHolders, keyCache)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -231,54 +247,66 @@ func (a *Aggregator) calcAggregations(prevRow *common.Row, currRow *common.Row, 
 	return nil
 }
 
-func (a *Aggregator) loadAggregateState(shardID uint64, keyBytes []byte, readRows *common.Rows, aggStateHolders *stateHolders) (*aggStateHolder, error) {
+func (a *Aggregator) loadAggregateState(shardID uint64, keyBytes []byte, readRows *common.Rows, aggStateHolders *stateHolders,
+	keyCache *simplelru.LRU) (*aggStateHolder, error) {
 	sKey := common.ByteSliceToStringZeroCopy(keyBytes)
 	stateHolder, ok := aggStateHolders.holdersMap[sKey] // maybe already cached for this batch
 	if !ok {
-		// Nope - try and load the aggregate state from storage
-		// We must use a linearizable get via raft here - even though we are on a replica there is no guarantee that
-		// the data has been applied to the state machine of all replicas when the previous write has completed
-		// successfully.
-		// TODO lru cache and bloom filter (?) to reduce gets
-		rowBytes, err := a.storage.LinearizableGet(shardID, keyBytes)
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
-		var currRow *common.Row
-		if rowBytes != nil {
-			// Doesn't matter if we use partial or full col types here as they are the same
-			if err := common.DecodeRow(rowBytes, a.AggTableInfo.ColumnTypes, readRows); err != nil {
+		// Look in the LRU cache
+		v, ok := keyCache.Get(sKey)
+		if ok {
+			stateHolder, ok = v.(*aggStateHolder)
+			if !ok {
+				panic("not an *aggStateHolder")
+			}
+			aggStateHolders.holdersMap[sKey] = stateHolder
+			stateHolder.aggState.SetUnchanged()
+			stateHolder.initialRow = stateHolder.row
+			stateHolder.row = nil
+		} else {
+			// Try and load the aggregate state from storage
+			// We must use a linearizable get via raft here - even though we are on a replica there is no guarantee that
+			// the data has been applied to the state machine of all replicas when the previous write has completed
+			// successfully.
+			rowBytes, err := a.storage.LinearizableGet(shardID, keyBytes)
+			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			r := readRows.GetRow(readRows.RowCount() - 1)
-			currRow = &r
-		}
-		numCols := len(a.colTypes)
-		aggState := aggfuncs.NewAggState(numCols)
-		stateHolder = &aggStateHolder{
-			aggState: aggState,
-		}
-		stateHolder.keyBytes = keyBytes
-		aggStateHolders.holdersMap[sKey] = stateHolder
-		aggStateHolders.holders = append(aggStateHolders.holders, stateHolder)
-		if currRow != nil {
-			// Initialise the agg state with the row from storage
-			if err := a.initAggStateWithRow(currRow, aggState, numCols); err != nil {
-				return nil, errors.WithStack(err)
+			var currRow *common.Row
+			if rowBytes != nil {
+				// Doesn't matter if we use partial or full col types here as they are the same
+				if err := common.DecodeRow(rowBytes, a.AggTableInfo.ColumnTypes, readRows); err != nil {
+					return nil, errors.WithStack(err)
+				}
+				r := readRows.GetRow(readRows.RowCount() - 1)
+				currRow = &r
 			}
-			stateHolder.initialRow = currRow
-		}
+			numCols := len(a.colTypes)
+			aggState := aggfuncs.NewAggState(numCols)
+			stateHolder = &aggStateHolder{
+				aggState: aggState,
+			}
+			stateHolder.keyBytes = keyBytes
+			aggStateHolders.holdersMap[sKey] = stateHolder
+			if currRow != nil {
+				// Initialise the agg state with the row from storage
+				if err := a.initAggStateWithRow(currRow, aggState, numCols); err != nil {
+					return nil, errors.WithStack(err)
+				}
+				stateHolder.initialRow = currRow
+			}
 
-		// copy the agg state here and set it as a field on the holder
-		stateHolder.initialRowBytes = rowBytes
+			// And put in lru cache
+			keyCache.Add(sKey, stateHolder)
+		}
 	}
 	return stateHolder, nil
 }
 
 func (a *Aggregator) storeAggregateResults(stateHolders *stateHolders, writeBatch *cluster.WriteBatch) error {
-	resultRows := a.rowsFactory.NewRows(len(stateHolders.holders))
+	resultRows := a.rowsFactory.NewRows(len(stateHolders.holdersMap))
 	rowCount := 0
-	for _, stateHolder := range stateHolders.holders {
+	for _, stateHolder := range stateHolders.holdersMap {
 		aggState := stateHolder.aggState
 		if aggState.IsChanged() {
 			for i, colType := range a.colTypes {
@@ -315,7 +343,6 @@ func (a *Aggregator) storeAggregateResults(stateHolders *stateHolders, writeBatc
 				return errors.WithStack(err)
 			}
 			writeBatch.AddPut(stateHolder.keyBytes, valueBuff)
-			stateHolder.rowBytes = valueBuff
 			rowCount++
 		}
 	}
@@ -440,4 +467,29 @@ func createAggFunctions(aggFunctionInfos []*AggregateFunctionInfo, colTypes []co
 func (a *Aggregator) ReCalcSchemaFromChildren() error {
 	// NOOP
 	return nil
+}
+
+func (a *Aggregator) getCacheForShard(shardID uint64) (*simplelru.LRU, error) {
+	var cache *simplelru.LRU
+	v, ok := a.keyCaches.Load(shardID)
+	if !ok {
+		a.cachesLock.Lock()
+		defer a.cachesLock.Unlock()
+		v, ok = a.keyCaches.Load(shardID)
+		if !ok {
+			var err error
+			cache, err = simplelru.NewLRU(a.lruCacheSize, nil)
+			if err != nil {
+				return nil, err
+			}
+			a.keyCaches.Store(shardID, cache)
+		}
+	}
+	if cache == nil {
+		cache, ok = v.(*simplelru.LRU)
+		if !ok {
+			panic("not a *simplelru.LRU")
+		}
+	}
+	return cache, nil
 }

--- a/push/exec_builder.go
+++ b/push/exec_builder.go
@@ -2,6 +2,7 @@ package push
 
 import (
 	"fmt"
+	"github.com/squareup/pranadb/conf"
 	"github.com/squareup/pranadb/tidb/planner"
 
 	"github.com/squareup/pranadb/errors"
@@ -15,7 +16,7 @@ import (
 
 // Builds the push DAG but does not register anything in memory
 func (m *MaterializedView) buildPushQueryExecution(pl *parplan.Planner, schema *common.Schema, query string, mvName string,
-	seqGenerator common.SeqGenerator) (exec.PushExecutor, []*common.InternalTableInfo, error) {
+	seqGenerator common.SeqGenerator, cfg *conf.Config) (exec.PushExecutor, []*common.InternalTableInfo, error) {
 
 	// Build the physical plan
 	physicalPlan, logicalPlan, _, err := pl.QueryToPlan(query, false, false)
@@ -23,7 +24,7 @@ func (m *MaterializedView) buildPushQueryExecution(pl *parplan.Planner, schema *
 		return nil, nil, errors.WithStack(err)
 	}
 	// Build initial dag from the plan
-	dag, internalTables, err := m.buildPushDAG(physicalPlan, 0, schema, mvName, seqGenerator)
+	dag, internalTables, err := m.buildPushDAG(physicalPlan, 0, schema, mvName, seqGenerator, cfg)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
@@ -44,7 +45,7 @@ func (m *MaterializedView) buildPushQueryExecution(pl *parplan.Planner, schema *
 
 // nolint: gocyclo
 func (m *MaterializedView) buildPushDAG(plan planner.PhysicalPlan, aggSequence int, schema *common.Schema, mvName string,
-	seqGenerator common.SeqGenerator) (exec.PushExecutor, []*common.InternalTableInfo, error) {
+	seqGenerator common.SeqGenerator, cfg *conf.Config) (exec.PushExecutor, []*common.InternalTableInfo, error) {
 	var internalTables []*common.InternalTableInfo
 	var executor exec.PushExecutor
 	var err error
@@ -117,17 +118,6 @@ func (m *MaterializedView) buildPushDAG(plan planner.PhysicalPlan, aggSequence i
 			pkCols[i] = i + nonFirstRowFuncs
 		}
 
-		//partialTableID := seqGenerator.GenerateSequence()
-		//partialTableName := fmt.Sprintf("%s-partial-aggtable-%d", mvName, aggSequence)
-		//aggSequence++
-		//partialTableInfo := &common.TableInfo{
-		//	ID:             partialTableID,
-		//	SchemaName:     schema.Name,
-		//	Name:           partialTableName,
-		//	PrimaryKeyCols: pkCols,
-		//	IndexInfos:     nil, // TODO
-		//	Internal:       true,
-		//}
 		fullTableID := seqGenerator.GenerateSequence()
 		fullTableName := fmt.Sprintf("%s-full-aggtable-%d", mvName, aggSequence)
 		aggSequence++
@@ -139,17 +129,13 @@ func (m *MaterializedView) buildPushDAG(plan planner.PhysicalPlan, aggSequence i
 			IndexInfos:     nil, // TODO
 			Internal:       true,
 		}
-		//partialAggInfo := &common.InternalTableInfo{
-		//	TableInfo:            partialTableInfo,
-		//	MaterializedViewName: mvName,
-		//}
-		//internalTables = append(internalTables, partialAggInfo)
 		fullAggInfo := &common.InternalTableInfo{
 			TableInfo:            fullTableInfo,
 			MaterializedViewName: mvName,
 		}
 		internalTables = append(internalTables, fullAggInfo)
-		executor, err = exec.NewAggregator(pkCols, aggFuncs, fullTableInfo, groupByCols, m.cluster, m.sharder)
+		lruCacheSize := cfg.AggregationCacheSizeRows / cfg.NumShards
+		executor, err = exec.NewAggregator(pkCols, aggFuncs, fullTableInfo, groupByCols, m.cluster, m.sharder, lruCacheSize)
 		if err != nil {
 			return nil, nil, errors.WithStack(err)
 		}
@@ -187,7 +173,7 @@ func (m *MaterializedView) buildPushDAG(plan planner.PhysicalPlan, aggSequence i
 
 	var childExecutors []exec.PushExecutor
 	for _, child := range plan.Children() {
-		childExecutor, it, err := m.buildPushDAG(child, aggSequence, schema, mvName, seqGenerator)
+		childExecutor, it, err := m.buildPushDAG(child, aggSequence, schema, mvName, seqGenerator, cfg)
 		if err != nil {
 			return nil, nil, errors.WithStack(err)
 		}

--- a/push/mv.go
+++ b/push/mv.go
@@ -31,7 +31,7 @@ func CreateMaterializedView(pe *Engine, pl *parplan.Planner, schema *common.Sche
 		cluster: pe.cluster,
 		sharder: pe.sharder,
 	}
-	dag, internalTables, err := mv.buildPushQueryExecution(pl, schema, query, mvName, seqGenerator)
+	dag, internalTables, err := mv.buildPushQueryExecution(pl, schema, query, mvName, seqGenerator, pe.cfg)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/sqltest/sql_large_cluster_test.go
+++ b/sqltest/sql_large_cluster_test.go
@@ -26,3 +26,11 @@ func TestSQLClusteredSevenNodesReplicationFive(t *testing.T) {
 	log.Info("Running TestSQLClusteredSevenNodesReplicationFive")
 	testSQL(t, false, 7, 5)
 }
+
+func TestSQLClusteredSevenNodesReplicationThree(t *testing.T) {
+	if testing.Short() {
+		t.Skip("-short: skipped")
+	}
+	log.Info("Running TestSQLClusteredSevenNodesReplicationFive")
+	testSQL(t, false, 7, 3)
+}


### PR DESCRIPTION
This caches aggregate rows in memory to avoid loading from storage for each batch.