### PR TITLE
Ignore table data after drop

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -82,6 +82,8 @@ type Cluster interface {
 	RegisterStartFill(expectedLeaders map[uint64]uint64, interruptor *interruptor.Interruptor) error
 
 	RegisterEndFill()
+
+	TableDropped(tableID uint64)
 }
 
 type ToDeleteBatch struct {

--- a/cluster/fake/fake_cluster.go
+++ b/cluster/fake/fake_cluster.go
@@ -455,3 +455,6 @@ func (f *FakeCluster) RegisterStartFill(expectedLeaders map[uint64]uint64, inter
 
 func (f *FakeCluster) RegisterEndFill() {
 }
+
+func (f *FakeCluster) TableDropped(tableID uint64) {
+}

--- a/common/util.go
+++ b/common/util.go
@@ -137,7 +137,7 @@ func DumpDataKey(bytes []byte) string {
 	tableID, _ := ReadUint64FromBufferBE(bytes, 8)
 	//The rest depends on the table
 	remaining := bytes[16:]
-	return fmt.Sprintf("sid:%05d|tid:%05d|k:%v", shardID, tableID, remaining)
+	return fmt.Sprintf("sid:%05d|tid:%05d|k:%v|raw:%v", shardID, tableID, remaining, bytes)
 }
 
 const atFalse = 0

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -24,48 +24,48 @@ const (
 )
 
 type Config struct {
-	NodeID                           int
-	ClusterID                        uint64 // All nodes in a Prana cluster must share the same ClusterID
-	RaftAddresses                    []string
-	NotifListenAddresses             []string
-	NumShards                        int
-	ReplicationFactor                int
-	DataDir                          string
-	TestServer                       bool
-	KafkaBrokers                     BrokerConfigs
-	DataSnapshotEntries              int
-	DataCompactionOverhead           int
-	SequenceSnapshotEntries          int
-	SequenceCompactionOverhead       int
-	LocksSnapshotEntries             int
-	LocksCompactionOverhead          int
-	EnableAPIServer                  bool
-	APIServerListenAddresses         []string
-	APITLSConfig                     tls.TLSConfig `help:"API TLS configuration" embed:"" prefix:"api-tls-"`
-	EnableSourceStats                bool
-	ProtobufDescriptorDir            string `help:"Directory containing protobuf file descriptor sets that Prana should load to use for decoding Kafka messages. Filenames must end with .bin" type:"existingdir"`
-	EnableLifecycleEndpoint          bool
-	LifeCycleListenAddress           string
-	StartupEndpointPath              string
-	ReadyEndpointPath                string
-	LiveEndpointPath                 string
-	MetricsBind                      string `help:"Bind address for Prometheus metrics." default:"localhost:9102" env:"METRICS_BIND"`
-	EnableMetrics                    bool
-	EnableFailureInjector            bool
-	ScreenDragonLogSpam              bool
-	RaftRTTMs                        int
-	RaftElectionRTT                  int
-	RaftHeartbeatRTT                 int
-	DisableFsync                     bool
-	DDProfilerTypes                  string
-	DDProfilerHostEnvVarName         string
-	DDProfilerPort                   int
-	DDProfilerServiceName            string
-	DDProfilerEnvironmentName        string
-	DDProfilerVersionName            string
-	AggregationCacheSizeRows         int // The maximum number of rows for an aggregation to cache in memory
-	MaxProcessBatchSize              int
-	MaxForwardWriteBatchSize         int
+	NodeID                     int
+	ClusterID                  uint64 // All nodes in a Prana cluster must share the same ClusterID
+	RaftAddresses              []string
+	NotifListenAddresses       []string
+	NumShards                  int
+	ReplicationFactor          int
+	DataDir                    string
+	TestServer                 bool
+	KafkaBrokers               BrokerConfigs
+	DataSnapshotEntries        int
+	DataCompactionOverhead     int
+	SequenceSnapshotEntries    int
+	SequenceCompactionOverhead int
+	LocksSnapshotEntries       int
+	LocksCompactionOverhead    int
+	EnableAPIServer            bool
+	APIServerListenAddresses   []string
+	APITLSConfig               tls.TLSConfig `help:"API TLS configuration" embed:"" prefix:"api-tls-"`
+	EnableSourceStats          bool
+	ProtobufDescriptorDir      string `help:"Directory containing protobuf file descriptor sets that Prana should load to use for decoding Kafka messages. Filenames must end with .bin" type:"existingdir"`
+	EnableLifecycleEndpoint    bool
+	LifeCycleListenAddress     string
+	StartupEndpointPath        string
+	ReadyEndpointPath          string
+	LiveEndpointPath           string
+	MetricsBind                string `help:"Bind address for Prometheus metrics." default:"localhost:9102" env:"METRICS_BIND"`
+	EnableMetrics              bool
+	EnableFailureInjector      bool
+	ScreenDragonLogSpam        bool
+	RaftRTTMs                  int
+	RaftElectionRTT            int
+	RaftHeartbeatRTT           int
+	DisableFsync               bool
+	DDProfilerTypes            string
+	DDProfilerHostEnvVarName   string
+	DDProfilerPort             int
+	DDProfilerServiceName      string
+	DDProfilerEnvironmentName  string
+	DDProfilerVersionName      string
+	AggregationCacheSizeRows   int // The maximum number of rows for an aggregation to cache in memory
+	MaxProcessBatchSize        int
+	MaxForwardWriteBatchSize   int
 }
 
 func (c *Config) ApplyDefaults() {

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -53,7 +53,6 @@ type Config struct {
 	EnableMetrics                    bool
 	EnableFailureInjector            bool
 	ScreenDragonLogSpam              bool
-	DisableShardPlacementSanityCheck bool
 	RaftRTTMs                        int
 	RaftElectionRTT                  int
 	RaftHeartbeatRTT                 int

--- a/pull/exec/remote_executor_test.go
+++ b/pull/exec/remote_executor_test.go
@@ -167,6 +167,10 @@ type testCluster struct {
 	rowsByShardOrig map[uint64]*common.Rows
 }
 
+func (t *testCluster) TableDropped(tableID uint64) {
+	panic("implement me")
+}
+
 func (t *testCluster) GetLeadersMap() (map[uint64]uint64, error) {
 	panic("implement me")
 }

--- a/push/mv.go
+++ b/push/mv.go
@@ -73,6 +73,7 @@ func (m *MaterializedView) Drop() error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
+	m.cluster.TableDropped(m.Info.ID)
 	return m.deleteTableData(m.Info.ID)
 }
 

--- a/push/source/source.go
+++ b/push/source/source.go
@@ -209,7 +209,7 @@ func (s *Source) Drop() error {
 	if err := s.cluster.DeleteAllDataInRangeForAllShardsLocally(startPrefix, endPrefix); err != nil {
 		return errors.WithStack(err)
 	}
-
+	s.cluster.TableDropped(s.sourceInfo.ID)
 	// Delete the table data
 	tableStartPrefix := common.AppendUint64ToBufferBE(nil, s.sourceInfo.ID)
 	tableEndPrefix := common.AppendUint64ToBufferBE(nil, s.sourceInfo.ID+1)

--- a/sqltest/sql_test_runner.go
+++ b/sqltest/sql_test_runner.go
@@ -201,7 +201,6 @@ func (w *sqlTestsuite) setupPranaCluster() {
 			cnf.ProtobufDescriptorDir = ProtoDescriptorDir
 			cnf.EnableFailureInjector = true
 			cnf.ScreenDragonLogSpam = true
-			cnf.DisableShardPlacementSanityCheck = true
 			cnf.RaftRTTMs = 25
 			cnf.DisableFsync = true // for performance
 			s, err := server.NewServer(*cnf)


### PR DESCRIPTION
Previously, it was possible that a write was made into a table via Raft, was replicated and written in two replicas ( a quorum) then the write returned. Then the table was dropped. The write to the 3rd replica (slow follower) then happened after the drop resulting in orphaned data. This was sometimes picked up in SQL tests.
Now we tell each shard state machine when a table is dropped and it adds the table id to a small cache of table ids to ignore.