### PR TITLE
Terminate query and DDL when client request is cancelled

### DIFF
--- a/api/http/api_test.go
+++ b/api/http/api_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -510,8 +511,8 @@ func (t *testSQLExecutor) ExecuteSQLStatement(execCtx *execctx.ExecutionContext,
 	return t.pe, nil
 }
 
-func (t *testSQLExecutor) CreateExecutionContext(schema *common.Schema) *execctx.ExecutionContext {
-	return execctx.NewExecutionContext("testcontext", schema)
+func (t *testSQLExecutor) CreateExecutionContext(ctx context.Context, schema *common.Schema) *execctx.ExecutionContext {
+	return execctx.NewExecutionContext(ctx, "testcontext", schema)
 }
 
 func (t *testSQLExecutor) GetState() (sql string, argTypes []common.ColumnType, args []interface{}, schema string, rows *common.Rows) {

--- a/client/client.go
+++ b/client/client.go
@@ -39,6 +39,7 @@ const (
 	minColWidth          = 5
 	maxLineWidthPropName = "max_line_width"
 	maxLineWidth         = 10000
+	queryBatchSize       = 10000
 )
 
 // Client is a simple Client used for executing statements against PranaDB, it used by the CLI and elsewhere
@@ -61,7 +62,7 @@ type Client struct {
 func NewClientUsingGRPC(serverAddress string, tlsConfig TLSConfig) *Client {
 	return &Client{
 		serverAddress: serverAddress,
-		batchSize:     10000,
+		batchSize:     queryBatchSize,
 		maxLineWidth:  defaultMaxLineWidth,
 		tlsConfig:     tlsConfig,
 	}
@@ -70,7 +71,7 @@ func NewClientUsingGRPC(serverAddress string, tlsConfig TLSConfig) *Client {
 func NewClientUsingHTTP(serverAddress string, tlsConfig TLSConfig) *Client {
 	return &Client{
 		serverAddress: serverAddress,
-		batchSize:     10000,
+		batchSize:     queryBatchSize,
 		maxLineWidth:  defaultMaxLineWidth,
 		useHTTPAPI:    true,
 		tlsConfig:     tlsConfig,

--- a/cluster/dragon/shard_odsm.go
+++ b/cluster/dragon/shard_odsm.go
@@ -382,6 +382,7 @@ func (s *ShardOnDiskStateMachine) handleSetLeader(batch *pebble.Batch, bytes []b
 }
 
 func (s *ShardOnDiskStateMachine) Lookup(i interface{}) (interface{}, error) {
+	defer common.PanicHandler()
 	buff, ok := i.([]byte)
 	if !ok {
 		panic("expected []byte")

--- a/command/create_source_command.go
+++ b/command/create_source_command.go
@@ -2,20 +2,19 @@ package command
 
 import (
 	"fmt"
+	"github.com/alecthomas/repr"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
-	"github.com/squareup/pranadb/interruptor"
-	"strings"
-	"sync"
-
-	"github.com/alecthomas/repr"
 	"github.com/squareup/pranadb/command/parser"
 	"github.com/squareup/pranadb/command/parser/selector"
 	"github.com/squareup/pranadb/common"
 	"github.com/squareup/pranadb/errors"
+	"github.com/squareup/pranadb/interruptor"
 	"github.com/squareup/pranadb/meta"
 	"github.com/squareup/pranadb/push/source"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"strings"
+	"sync"
 )
 
 type CreateSourceCommand struct {

--- a/execctx/execctx.go
+++ b/execctx/execctx.go
@@ -1,6 +1,7 @@
 package execctx
 
 import (
+	"context"
 	"github.com/squareup/pranadb/cluster"
 	"github.com/squareup/pranadb/common"
 	"github.com/squareup/pranadb/parplan"
@@ -12,13 +13,15 @@ type ExecutionContext struct {
 	planner      *parplan.Planner
 	QueryInfo    *cluster.QueryExecutionInfo
 	CurrentQuery interface{} // typed as interface{} to avoid circular dependency with pull
+	Ctx          context.Context
 }
 
-func NewExecutionContext(id string, schema *common.Schema) *ExecutionContext {
+func NewExecutionContext(ctx context.Context, id string, schema *common.Schema) *ExecutionContext {
 	return &ExecutionContext{
 		ID:        id,
 		QueryInfo: new(cluster.QueryExecutionInfo),
 		Schema:    schema,
+		Ctx:       ctx,
 	}
 }
 

--- a/meta/schema/loader_test.go
+++ b/meta/schema/loader_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"github.com/squareup/pranadb/cluster/fake"
 	"github.com/squareup/pranadb/failinject"
 	"github.com/squareup/pranadb/remoting"
@@ -134,7 +135,7 @@ func TestLoader(t *testing.T) {
 			for _, ddl := range test.ddl {
 				numTables := 0
 				schema := metaController.GetOrCreateSchema(ddl.schema)
-				session := executor.CreateExecutionContext(schema)
+				session := executor.CreateExecutionContext(context.Background(), schema)
 				for _, query := range ddl.queries {
 					_, err := executor.ExecuteSQLStatement(session, query, nil, nil)
 					numTables++

--- a/pull/exec/remote_executor.go
+++ b/pull/exec/remote_executor.go
@@ -2,14 +2,12 @@ package exec
 
 import (
 	"fmt"
+	"github.com/squareup/pranadb/cluster"
+	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/errors"
 	"github.com/squareup/pranadb/meta"
 	"strings"
 	"sync/atomic"
-
-	"github.com/squareup/pranadb/errors"
-
-	"github.com/squareup/pranadb/cluster"
-	"github.com/squareup/pranadb/common"
 )
 
 type RemoteExecutor struct {

--- a/remoting/adaptor.go
+++ b/remoting/adaptor.go
@@ -1,13 +1,5 @@
 package remoting
 
-// RPCWrapper is a helper for when you always want to RPC to the same server
-type RPCWrapper struct {
-	serverAddress string
-	client        *Client
-}
-
-var _ RPCSender = &RPCWrapper{}
-
 // Adapt the current Prana expectations to the new remoting
 
 type Broadcaster interface {
@@ -16,26 +8,6 @@ type Broadcaster interface {
 }
 
 var _ Broadcaster = &BroadcastWrapper{}
-
-type RPCSender interface {
-	SendRPC(request ClusterMessage) (ClusterMessage, error)
-	Stop()
-}
-
-func NewRPCWrapper(serverAddress string) *RPCWrapper {
-	return &RPCWrapper{
-		serverAddress: serverAddress,
-		client:        &Client{},
-	}
-}
-
-func (r *RPCWrapper) SendRPC(request ClusterMessage) (ClusterMessage, error) {
-	return r.client.SendRPC(request, r.serverAddress)
-}
-
-func (r *RPCWrapper) Stop() {
-	r.client.Stop()
-}
 
 // BroadcastWrapper is a helper for when you always want to broadcast to the same servers
 type BroadcastWrapper struct {

--- a/remoting/cluster_message.go
+++ b/remoting/cluster_message.go
@@ -224,6 +224,7 @@ func writeMessage(msgType messageType, msg []byte, conn net.Conn) error {
 }
 
 func readMessage(handler messageHandler, conn net.Conn, closeAction func()) {
+	defer common.PanicHandler()
 	var msgBuf []byte
 	readBuff := make([]byte, readBuffSize)
 	msgLen := -1

--- a/sqltest/testdata/gen_source_test_out.txt
+++ b/sqltest/testdata/gen_source_test_out.txt
@@ -74,7 +74,7 @@ create source test_source_2(
     ),
     properties = (
         "prana.loadclient.maxmessagesperconsumer" = "10",
-        "prana.loadclient.maxrateperconsumer" = "1"
+        "prana.source.maxingestrate" = "1"
     )
 );
 0 rows returned

--- a/sqltest/testdata/gen_source_test_script.txt
+++ b/sqltest/testdata/gen_source_test_script.txt
@@ -46,7 +46,7 @@ create source test_source_2(
     ),
     properties = (
         "prana.loadclient.maxmessagesperconsumer" = "10",
-        "prana.loadclient.maxrateperconsumer" = "1"
+        "prana.source.maxingestrate" = "1"
     )
 );
 


### PR DESCRIPTION
When a client connection is terminated we need to make sure that the DDL, if any, is cancelled and any query resources cleaned up