### PR TITLE
Allow writeForwardBatch with localOnly=true to be sent remotely, but …

### DIFF
--- a/cluster/dragon/dragon.go
+++ b/cluster/dragon/dragon.go
@@ -494,7 +494,10 @@ func (d *Dragon) WriteForwardBatch(batch *cluster.WriteBatch, localOnly bool) er
 	buff = append(buff, shardStateMachineCommandForwardWrite)
 	buff = batch.Serialize(buff)
 	if localOnly {
-		retVal, _, err := d.sendPropose(batch.ShardID, buff, localOnly)
+		// For a local-only WriteForwardBatch we must not send the processor as this can cause deadlock if
+		// the forward batch is being written from processing of another batch on the same processor
+		// It is ok to send remotely, but as a propose - which bypasses the processor
+		retVal, _, err := d.sendPropose(batch.ShardID, buff, false)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/push/engine.go
+++ b/push/engine.go
@@ -505,6 +505,7 @@ func (p *Engine) processReceiveBatch(batch *receiveBatch) error {
 		return err
 	}
 
+	// If we get this far we can commit any local changes and deletes from the receiver table
 	if err := p.cluster.WriteBatch(batch.writeBatch, true); err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
…as a propose, to avoid queuing on the processor and potential deadlock.