### PR TITLE
feat: Add support for intra PranaDB intra nodes mTLS

### DIFF
--- a/cfg/example.conf
+++ b/cfg/example.conf
@@ -47,6 +47,14 @@ http-api-server-tls-client-certs-path = "path/to/my/ca.crt"
 http-api-server-tls-client-auth = "require-and-verify-client-cert"
 */
 
+intra-cluster-tls-enable-tls = false
+/*
+intra-cluster-tls-enable-tls = true // Set to true to enable TLS for Raft logs (DragonBoat)
+intra-cluster-tls-key-path = "path/to/my/cert.key"
+intra-cluster-tls-cert-path = "path/to/my/cert.crt"
+intra-cluster-tls-client-certs-path = "path/to/my/ca.crt"
+*/
+
 num-shards         = 30 // The total number of shards in the cluster
 replication-factor = 3 // The number of replicas - each write will be replicated to this many replicas
 data-dir           = "prana-data" // The base directory for storing data

--- a/cluster/dragon/dragon.go
+++ b/cluster/dragon/dragon.go
@@ -347,6 +347,12 @@ func (d *Dragon) start0() error {
 		RaftEventListener: d.procMgr,
 	}
 	nhc.Expert.LogDB.EnableFsync = !d.cnf.DisableFsync
+	if d.cnf.IntraClusterTLSConfig.Enabled {
+		nhc.MutualTLS = true
+		nhc.CAFile = d.cnf.IntraClusterTLSConfig.ClientCertsPath
+		nhc.CertFile = d.cnf.IntraClusterTLSConfig.CertPath
+		nhc.KeyFile = d.cnf.IntraClusterTLSConfig.KeyPath
+	}
 
 	nh, err := dragonboat.NewNodeHost(nhc)
 	if err != nil {

--- a/cluster/dragon/integration/test_cluster.go
+++ b/cluster/dragon/integration/test_cluster.go
@@ -1,0 +1,100 @@
+package integration
+
+import (
+	"time"
+
+	"github.com/squareup/pranadb/cluster"
+	"github.com/squareup/pranadb/cluster/dragon"
+	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/conf"
+	"github.com/squareup/pranadb/errors"
+)
+
+// TestCluster is a DragonBoat cluster for integration testing.
+type TestCluster struct {
+	dataDir           string
+	numShards         int
+	replicationFactor int
+	tlsConfig         conf.TLSConfig
+	nodes             []*dragon.Dragon
+}
+
+// NewTestCluster creates a new DragonBoat integration test cluster.
+func NewTestCluster(dataDir string, numShards int, replicationFactor int, tlsConfig conf.TLSConfig) *TestCluster {
+	return &TestCluster{
+		dataDir:           dataDir,
+		numShards:         numShards,
+		replicationFactor: replicationFactor,
+		tlsConfig:         tlsConfig,
+	}
+}
+
+// Start starts a DragonBoat cluster for integration testing
+func (c *TestCluster) Start() error {
+	nodeAddresses := []string{
+		"localhost:63101",
+		"localhost:63102",
+		"localhost:63103",
+	}
+
+	chans := make([]chan error, len(nodeAddresses))
+	c.nodes = make([]*dragon.Dragon, len(nodeAddresses))
+	for i := 0; i < len(chans); i++ {
+		ch := make(chan error)
+		chans[i] = ch
+		cnf := conf.NewDefaultConfig()
+		cnf.NodeID = i
+		cnf.ClusterID = 123
+		cnf.RaftListenAddresses = nodeAddresses
+		cnf.NumShards = c.numShards
+		cnf.DataDir = c.dataDir
+		cnf.ReplicationFactor = c.replicationFactor
+		cnf.TestServer = true
+		cnf.IntraClusterTLSConfig = c.tlsConfig
+		clus, err := dragon.NewDragon(*cnf, &common.AtomicBool{})
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		c.nodes[i] = clus
+		clus.RegisterShardListenerFactory(&cluster.DummyShardListenerFactory{})
+		clus.SetRemoteQueryExecutionCallback(&cluster.DummyRemoteQueryExecutionCallback{})
+
+		go startNode(clus, ch)
+	}
+
+	for i := 0; i < len(chans); i++ {
+		err, ok := <-chans[i]
+		if !ok {
+			return errors.Error("channel was closed")
+		}
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	time.Sleep(5 * time.Second)
+	return nil
+}
+
+// Stop stops the test cluster.
+func (c *TestCluster) Stop() error {
+	for _, node := range c.nodes {
+		err := node.Stop()
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	return nil
+}
+
+// GetLocalNodeAndShard retrieves the local node and shard.
+func (c *TestCluster) GetLocalNodeAndShard() (*dragon.Dragon, uint64) {
+	clust := c.nodes[0]
+	shardID := clust.GetLocalShardIDs()[0]
+	return clust, shardID
+}
+
+func startNode(clus cluster.Cluster, ch chan error) {
+	err := clus.Start()
+	ch <- err
+}

--- a/cluster/dragon/mtlstest/mtls_test.go
+++ b/cluster/dragon/mtlstest/mtls_test.go
@@ -1,0 +1,100 @@
+package mtlstest
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/squareup/pranadb/cluster"
+	"github.com/squareup/pranadb/cluster/dragon/integration"
+	"github.com/squareup/pranadb/conf"
+	"github.com/squareup/pranadb/errors"
+	"github.com/squareup/pranadb/internal/testcerts"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	numShards         = 3
+	replicationFactor = 3
+)
+
+type tearDownFunc func(t *testing.T)
+
+func setupDragonCluster(t *testing.T) (*integration.TestCluster, tearDownFunc) {
+	t.Helper()
+
+	dataDir, err := ioutil.TempDir("", "dragon-mtls-test")
+	require.NoError(t, err, "failed to create temp dir")
+	tlsCertsDir, err := ioutil.TempDir("", "dragon-tls-certs")
+	require.NoError(t, err, "failed to create tls certs dir")
+	tlsConfig, err := createTLSConfig(tlsCertsDir)
+	require.NoError(t, err)
+
+	testCluster := integration.NewTestCluster(dataDir, numShards, replicationFactor, tlsConfig)
+	err = testCluster.Start()
+	require.NoError(t, err, "failed to start test dragon cluster")
+
+	return testCluster, func(t *testing.T) {
+		t.Helper()
+		_ = testCluster.Stop()
+		defer func() {
+			// We want to do this even if stopDragonCluster fails hence the extra defer
+			err := os.RemoveAll(dataDir)
+			require.NoError(t, err, "failed to remove test dir")
+		}()
+		defer func() {
+			// We want to do this even if stopDragonCluster fails hence the extra defer
+			err := os.RemoveAll(tlsCertsDir)
+			require.NoError(t, err, "failed to remove tls certs dir")
+		}()
+	}
+}
+
+func TestLocalPutGet(t *testing.T) {
+	testCluster, tearDown := setupDragonCluster(t)
+	defer tearDown(t)
+
+	node, localShard := testCluster.GetLocalNodeAndShard()
+
+	key := []byte("somekey")
+	value := []byte("somevalue")
+
+	kvPair := cluster.KVPair{
+		Key:   key,
+		Value: value,
+	}
+
+	wb := cluster.NewWriteBatch(localShard)
+	wb.AddPut(kvPair.Key, kvPair.Value)
+
+	err := node.WriteBatch(wb, false)
+	require.NoError(t, err)
+
+	res, err := node.LocalGet(key)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	require.Equal(t, string(value), string(res))
+}
+
+func createTLSConfig(certsDir string) (conf.TLSConfig, error) {
+	caCert, err := testcerts.CreateTestCACert("acme CA")
+	config := conf.TLSConfig{}
+	if err != nil {
+		return config, errors.Wrapf(err, "failed to create ca cert")
+	}
+	caCertPath, err := testcerts.WritePemToTmpFile(certsDir, caCert.Pem.Bytes())
+	if err != nil {
+		return config, errors.Wrapf(err, "failed to write pem file")
+	}
+
+	certPath, keyPath, err := testcerts.CreateCertKeyPairToTmpFile(certsDir, caCert, "acme badgers ltd.")
+	if err != nil {
+		return config, errors.Wrapf(err, "failed to cert key pair")
+	}
+	config.Enabled = true
+	config.ClientCertsPath = caCertPath
+	config.CertPath = certPath
+	config.KeyPath = keyPath
+	return config, nil
+}

--- a/cmd/pranadb/runner_test.go
+++ b/cmd/pranadb/runner_test.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/squareup/pranadb/conf"
 	"github.com/stretchr/testify/require"
@@ -109,5 +110,13 @@ func createConfigWithAllFields() conf.Config {
 		DDProfilerPort:            1324,
 		DDProfilerVersionName:     "2.3",
 		DDProfilerHostEnvVarName:  "FOO_IP",
+
+		IntraClusterTLSConfig: conf.TLSConfig{
+			Enabled:         true,
+			KeyPath:         "intra-cluster-key-path",
+			CertPath:        "intra-cluster-cert-path",
+			ClientCertsPath: "intra-cluster-client-certs-path",
+			ClientAuth:      "require-and-verify-client-cert",
+		},
 	}
 }

--- a/cmd/pranadb/testdata/config.hcl
+++ b/cmd/pranadb/testdata/config.hcl
@@ -82,3 +82,9 @@ dd-profiler-environment-name      = "playing"
 dd-profiler-port                  = 1324
 dd-profiler-version-name          = "2.3"
 dd-profiler-host-env-var-name     = "FOO_IP"
+
+intra-cluster-tls-enabled       = true
+intra-cluster-tls-key-path      = "intra-cluster-key-path"
+intra-cluster-tls-cert-path     = "intra-cluster-cert-path"
+intra-cluster-tls-client-certs-path = "intra-cluster-client-certs-path"
+intra-cluster-tls-client-auth = "require-and-verify-client-cert"

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -2,6 +2,7 @@ package conf
 
 import (
 	"fmt"
+
 	"github.com/squareup/pranadb/errors"
 )
 
@@ -24,6 +25,7 @@ type Config struct {
 	NodeID                       int
 	ClusterID                    uint64 // All nodes in a Prana cluster must share the same ClusterID
 	RaftListenAddresses          []string
+	IntraClusterTLSConfig        TLSConfig `embed:"" prefix:"intra-cluster-tls-"`
 	RemotingListenAddresses      []string
 	NumShards                    int
 	ReplicationFactor            int
@@ -262,6 +264,17 @@ func (c *Config) Validate() error { //nolint:gocyclo
 	}
 	if c.MaxForwardWriteBatchSize < 1 {
 		return errors.NewInvalidConfigurationError("MaxForwardWriteBatchSize must be > 0")
+	}
+	if c.IntraClusterTLSConfig.Enabled {
+		if c.IntraClusterTLSConfig.CertPath == "" {
+			return errors.NewInvalidConfigurationError("IntraClusterTLSConfig.CertPath must be specified if intra cluster TLS is enabled")
+		}
+		if c.IntraClusterTLSConfig.KeyPath == "" {
+			return errors.NewInvalidConfigurationError("IntraClusterTLSConfig.KeyPath must be specified if intra cluster TLS is enabled")
+		}
+		if c.IntraClusterTLSConfig.ClientCertsPath == "" {
+			return errors.NewInvalidConfigurationError("IntraClusterTLSConfig.ClientCertsPath must be provided if intra cluster TLS is enabled")
+		}
 	}
 
 	return nil

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -2,9 +2,10 @@ package conf
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/squareup/pranadb/errors"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 type configPair struct {
@@ -133,6 +134,24 @@ func grpcAPIServerTLSCertPathNotSpecifiedConfig() Config {
 func grpcAPIServerNoClientCerts() Config {
 	cnf := confAllFields
 	cnf.GRPCAPIServerTLSConfig.ClientCertsPath = ""
+	return cnf
+}
+
+func intraClusterTLSCertPathNotSpecifiedConfig() Config {
+	cnf := confAllFields
+	cnf.IntraClusterTLSConfig.CertPath = ""
+	return cnf
+}
+
+func intraClusterTLSKeyPathNotSpecifiedConfig() Config {
+	cnf := confAllFields
+	cnf.IntraClusterTLSConfig.KeyPath = ""
+	return cnf
+}
+
+func intraClusterTLSCAPathNotSpecifiedConfig() Config {
+	cnf := confAllFields
+	cnf.IntraClusterTLSConfig.ClientCertsPath = ""
 	return cnf
 }
 
@@ -345,6 +364,10 @@ var invalidConfigs = []configPair{
 	{"PDB3000 - Invalid configuration: GRPCAPIServerTLSConfig.KeyPath must be specified for GRPC API server", grpcAPIServerTLSKeyPathNotSpecifiedConfig()},
 	{"PDB3000 - Invalid configuration: GRPCAPIServerTLSConfig.CertPath must be specified for GRPC API server", grpcAPIServerTLSCertPathNotSpecifiedConfig()},
 	{"PDB3000 - Invalid configuration: GRPCAPIServerTLSConfig.ClientCertsPath must be provided if client auth is enabled", grpcAPIServerNoClientCerts()},
+
+	{"PDB3000 - Invalid configuration: IntraClusterTLSConfig.KeyPath must be specified if intra cluster TLS is enabled", intraClusterTLSKeyPathNotSpecifiedConfig()},
+	{"PDB3000 - Invalid configuration: IntraClusterTLSConfig.CertPath must be specified if intra cluster TLS is enabled", intraClusterTLSCertPathNotSpecifiedConfig()},
+	{"PDB3000 - Invalid configuration: IntraClusterTLSConfig.ClientCertsPath must be provided if intra cluster TLS is enabled", intraClusterTLSCAPathNotSpecifiedConfig()},
 }
 
 func TestValidate(t *testing.T) {
@@ -404,4 +427,11 @@ var confAllFields = Config{
 	RaftElectionRTT:          100,
 	MaxProcessBatchSize:      DefaultMaxForwardWriteBatchSize,
 	MaxForwardWriteBatchSize: DefaultMaxForwardWriteBatchSize,
+	IntraClusterTLSConfig: TLSConfig{
+		Enabled:         true,
+		KeyPath:         "intra_cluster_key_path",
+		CertPath:        "intra_cluster_cert_path",
+		ClientCertsPath: "intra_cluster_client_certs_path",
+		ClientAuth:      "intra_cluster_client_auth",
+	},
 }

--- a/local-deployment/conf/pranadb.conf
+++ b/local-deployment/conf/pranadb.conf
@@ -41,6 +41,14 @@ http-api-server-tls-client-certs-path = "path/to/my/ca.crt"
 http-api-server-tls-client-auth = "require-and-verify-client-cert"
 */
 
+intra-cluster-tls-enable-tls = false
+/*
+intra-cluster-tls-enable-tls = true // Set to true to enable TLS for Raft logs (DragonBoat)
+intra-cluster-tls-key-path = "path/to/my/cert.key"
+intra-cluster-tls-cert-path = "path/to/my/cert.crt"
+intra-cluster-tls-client-certs-path = "path/to/my/ca.crt"
+*/
+
 num-shards         = 30 // The total number of shards in the cluster
 replication-factor = 3 // The number of replicas - each write will be replicated to this many replicas
 data-dir           = "prana-data" // The base directory for storing data

--- a/sqltest/mtls_sql_test.go
+++ b/sqltest/mtls_sql_test.go
@@ -1,0 +1,18 @@
+//go:build mtlssqltest
+// +build mtlssqltest
+
+package sqltest
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestSQLClusteredThreeNodesTLS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("-short: skipped")
+	}
+	log.Info("Running TestSQLClusteredThreeNodesTLS")
+	testSQL(t, false, 3, 3, true, true, tlsKeysInfo)
+}

--- a/sqltest/sql_large_cluster_test.go
+++ b/sqltest/sql_large_cluster_test.go
@@ -4,8 +4,9 @@
 package sqltest
 
 import (
-	log "github.com/sirupsen/logrus"
 	"testing"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // These tests are run in a separate CI run as they can take a longer time to run
@@ -16,7 +17,7 @@ func TestSQLClusteredFiveNodes(t *testing.T) {
 	}
 
 	log.Info("Running TestSQLClusteredFiveNodes")
-	testSQL(t, false, 5, 3, false, tlsKeysInfo)
+	testSQL(t, false, 5, 3, false, false, tlsKeysInfo)
 }
 
 func TestSQLClusteredSevenNodesReplicationFive(t *testing.T) {
@@ -24,7 +25,7 @@ func TestSQLClusteredSevenNodesReplicationFive(t *testing.T) {
 		t.Skip("-short: skipped")
 	}
 	log.Info("Running TestSQLClusteredSevenNodesReplicationFive")
-	testSQL(t, false, 7, 5, false, tlsKeysInfo)
+	testSQL(t, false, 7, 5, false, false, tlsKeysInfo)
 }
 
 func TestSQLClusteredSevenNodesReplicationThree(t *testing.T) {
@@ -32,5 +33,5 @@ func TestSQLClusteredSevenNodesReplicationThree(t *testing.T) {
 		t.Skip("-short: skipped")
 	}
 	log.Info("Running TestSQLClusteredSevenNodesReplicationFive")
-	testSQL(t, false, 7, 3, false, tlsKeysInfo)
+	testSQL(t, false, 7, 3, false, false, tlsKeysInfo)
 }

--- a/sqltest/sql_test.go
+++ b/sqltest/sql_test.go
@@ -4,21 +4,22 @@
 package sqltest
 
 import (
-	log "github.com/sirupsen/logrus"
-	"github.com/squareup/pranadb/internal/testcerts"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/squareup/pranadb/internal/testcerts"
 )
 
 func TestSQLFakeCluster(t *testing.T) {
 	log.Debug("Running TestSQLFakeCluster")
-	testSQL(t, true, 1, 0, false, tlsKeysInfo)
+	testSQL(t, true, 1, 0, false, false, tlsKeysInfo)
 }
 
 func TestSQLFakeClusterUsingHTTPAPI(t *testing.T) {
 	log.Debug("Running TestSQLFakeClusterUsingHTTPAPI")
-	testSQL(t, true, 1, 0, true, tlsKeysInfo)
+	testSQL(t, true, 1, 0, true, false, tlsKeysInfo)
 }
 
 func TestSQLClusteredThreeNodes(t *testing.T) {
@@ -26,7 +27,7 @@ func TestSQLClusteredThreeNodes(t *testing.T) {
 		t.Skip("-short: skipped")
 	}
 	log.Info("Running TestSQLClusteredThreeNodes")
-	testSQL(t, false, 3, 3, false, tlsKeysInfo)
+	testSQL(t, false, 3, 3, false, false, tlsKeysInfo)
 }
 
 var tlsKeysInfo *TLSKeysInfo
@@ -49,12 +50,18 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("failed to cert key pair %v", err)
 	}
+	intraClusterCertPath, intraClusterKeyPath, err := testcerts.CreateCertKeyPairToTmpFile(tmpDir, nil, "acme badgers ltd.")
+	if err != nil {
+		log.Fatalf("failed to create cert key pair %v", err)
+	}
 
 	tlsKeysInfo = &TLSKeysInfo{
-		ServerCertPath: serverCertPath,
-		ServerKeyPath:  serverKeyPath,
-		ClientCertPath: clientCertPath,
-		ClientKeyPath:  clientKeyPath,
+		ServerCertPath:       serverCertPath,
+		ServerKeyPath:        serverKeyPath,
+		ClientCertPath:       clientCertPath,
+		ClientKeyPath:        clientKeyPath,
+		IntraClusterCertPath: intraClusterCertPath,
+		IntraClusterKeyPath:  intraClusterKeyPath,
 	}
 
 	defer func() {


### PR DESCRIPTION
This PR allows configuring mTLS for PranaDB intra node communication, mainly for the Raft protocol. Any other intra-node service in PranaDB can use the same certs for communication. That's why the name of the argument is `intra-cluster-tls`. The changes include:

* Prefixed arguments for intra cluster TLS config `intra-cluster-tls`.
* DragonBoat mTLS integration test.
* Created a test Dragon cluster component in the `integration` package to use in the mTLS test. `dragon_integration_test.go` and `dragon_snapshot_test.go` can use this component for testing.

https://github.com/cashapp/pranadb/issues/535