### PR TITLE
feat: Enable mTLS for remoting service

### DIFF
--- a/api/grpc/server.go
+++ b/api/grpc/server.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"context"
 	"fmt"
+
 	"github.com/squareup/pranadb/api"
 
 	"net"
@@ -79,7 +80,7 @@ func (s *GRPCAPIServer) Start() error {
 }
 
 func (s *GRPCAPIServer) getTLSOpt() (grpc.ServerOption, error) {
-	tlsConf, err := api.CreateServerTLSConfig(s.tlsConfig)
+	tlsConf, err := common.CreateServerTLSConfig(s.tlsConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -4,6 +4,16 @@ import (
 	"context"
 	"encoding/csv"
 	"fmt"
+	"io"
+	"math"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/golang/protobuf/proto"
 	log "github.com/sirupsen/logrus"
 	"github.com/squareup/pranadb/api"
@@ -16,15 +26,6 @@ import (
 	"github.com/squareup/pranadb/protolib"
 	"github.com/squareup/pranadb/pull/exec"
 	"google.golang.org/protobuf/types/descriptorpb"
-	"io"
-	"math"
-	"net"
-	"net/http"
-	"net/url"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
 )
 
 type HTTPAPIServer struct {
@@ -67,7 +68,7 @@ func NewHTTPAPIServer(listenAddress string, apiPath string, executor sqlExecutor
 }
 
 func (s *HTTPAPIServer) Start() error {
-	tlsConf, err := api.CreateServerTLSConfig(s.tlsConf)
+	tlsConf, err := common.CreateServerTLSConfig(s.tlsConf)
 	if err != nil {
 		return err
 	}

--- a/api/util.go
+++ b/api/util.go
@@ -1,13 +1,9 @@
 package api
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"github.com/alecthomas/participle/v2"
 	"github.com/squareup/pranadb/common"
-	"github.com/squareup/pranadb/conf"
 	"github.com/squareup/pranadb/errors"
-	"io/ioutil"
 )
 
 func MaybeConvertError(err error) errors.PranaError {
@@ -20,48 +16,4 @@ func MaybeConvertError(err error) errors.PranaError {
 		return errors.NewInvalidStatementError(participleErr.Error())
 	}
 	return common.LogInternalError(err)
-}
-
-func CreateServerTLSConfig(config conf.TLSConfig) (*tls.Config, error) {
-	if !config.Enabled {
-		return nil, nil
-	}
-	tlsConfig := &tls.Config{ // nolint: gosec
-		MinVersion: tls.VersionTLS12,
-	}
-	keyPair, err := common.CreateKeyPair(config.CertPath, config.KeyPath)
-	if err != nil {
-		return nil, err
-	}
-	tlsConfig.Certificates = []tls.Certificate{keyPair}
-	if config.ClientCertsPath != "" {
-		clientCerts, err := ioutil.ReadFile(config.ClientCertsPath)
-		if err != nil {
-			return nil, err
-		}
-		trustedCertPool := x509.NewCertPool()
-		if ok := trustedCertPool.AppendCertsFromPEM(clientCerts); !ok {
-			return nil, errors.Errorf("failed to append trusted certs PEM (invalid PEM block?)")
-		}
-		tlsConfig.ClientCAs = trustedCertPool
-	}
-	clientAuth, ok := clientAuthTypeMap[config.ClientAuth]
-	if !ok {
-		return nil, errors.Errorf("invalid tls client auth setting '%s'", config.ClientAuth)
-	}
-	if config.ClientCertsPath != "" && config.ClientAuth == "" {
-		// If client certs provided then default to client auth required
-		clientAuth = tls.RequireAndVerifyClientCert
-	}
-	tlsConfig.ClientAuth = clientAuth
-	return tlsConfig, nil
-}
-
-var clientAuthTypeMap = map[string]tls.ClientAuthType{
-	conf.ClientAuthModeNoClientCert:               tls.NoClientCert,
-	conf.ClientAuthModeRequestClientCert:          tls.RequestClientCert,
-	conf.ClientAuthModeRequireAnyClientCert:       tls.RequireAnyClientCert,
-	conf.ClientAuthModeVerifyClientCertIfGiven:    tls.VerifyClientCertIfGiven,
-	conf.ClientAuthModeRequireAndVerifyClientCert: tls.RequireAndVerifyClientCert,
-	conf.ClientAuthModeUnspecified:                tls.NoClientCert,
 }

--- a/cluster/dragon/dragon.go
+++ b/cluster/dragon/dragon.go
@@ -371,9 +371,16 @@ func (d *Dragon) Start() error { // nolint:gocyclo
 		return nil
 	}
 
-	d.requestClient = &remoting.Client{}
+	requestClient, err := remoting.NewClient(d.cnf.IntraClusterTLSConfig)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	d.requestClient = requestClient
 
-	d.procMgr.Start()
+	err = d.procMgr.Start()
+	if err != nil {
+		return errors.WithStack(err)
+	}
 
 	if err := d.start0(); err != nil {
 		return err
@@ -381,7 +388,7 @@ func (d *Dragon) Start() error { // nolint:gocyclo
 
 	log.Debugf("Joining groups on node %d", d.cnf.NodeID)
 
-	err := d.joinSequenceGroup()
+	err = d.joinSequenceGroup()
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/common/tls_config.go
+++ b/common/tls_config.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+
+	"github.com/squareup/pranadb/conf"
+	"github.com/squareup/pranadb/errors"
+)
+
+func CreateServerTLSConfig(config conf.TLSConfig) (*tls.Config, error) {
+	if !config.Enabled {
+		return nil, nil
+	}
+	tlsConfig := &tls.Config{ // nolint: gosec
+		MinVersion: tls.VersionTLS12,
+	}
+	keyPair, err := CreateKeyPair(config.CertPath, config.KeyPath)
+	if err != nil {
+		return nil, err
+	}
+	tlsConfig.Certificates = []tls.Certificate{keyPair}
+	if config.ClientCertsPath != "" {
+		clientCerts, err := ioutil.ReadFile(config.ClientCertsPath)
+		if err != nil {
+			return nil, err
+		}
+		trustedCertPool := x509.NewCertPool()
+		if ok := trustedCertPool.AppendCertsFromPEM(clientCerts); !ok {
+			return nil, errors.Errorf("failed to append trusted certs PEM (invalid PEM block?)")
+		}
+		tlsConfig.ClientCAs = trustedCertPool
+	}
+	clientAuth, ok := clientAuthTypeMap[config.ClientAuth]
+	if !ok {
+		return nil, errors.Errorf("invalid tls client auth setting '%s'", config.ClientAuth)
+	}
+	if config.ClientCertsPath != "" && config.ClientAuth == "" {
+		// If client certs provided then default to client auth required
+		clientAuth = tls.RequireAndVerifyClientCert
+	}
+	tlsConfig.ClientAuth = clientAuth
+	return tlsConfig, nil
+}
+
+var clientAuthTypeMap = map[string]tls.ClientAuthType{
+	conf.ClientAuthModeNoClientCert:               tls.NoClientCert,
+	conf.ClientAuthModeRequestClientCert:          tls.RequestClientCert,
+	conf.ClientAuthModeRequireAnyClientCert:       tls.RequireAnyClientCert,
+	conf.ClientAuthModeVerifyClientCertIfGiven:    tls.VerifyClientCertIfGiven,
+	conf.ClientAuthModeRequireAndVerifyClientCert: tls.RequireAndVerifyClientCert,
+	conf.ClientAuthModeUnspecified:                tls.NoClientCert,
+}

--- a/remoting/adaptor.go
+++ b/remoting/adaptor.go
@@ -1,5 +1,10 @@
 package remoting
 
+import (
+	"github.com/squareup/pranadb/conf"
+	"github.com/squareup/pranadb/errors"
+)
+
 // Adapt the current Prana expectations to the new remoting
 
 type Broadcaster interface {
@@ -15,11 +20,15 @@ type BroadcastWrapper struct {
 	client          *Client
 }
 
-func NewBroadcastWrapper(serverAddresses ...string) *BroadcastWrapper {
+func NewBroadcastWrapper(tlsConfig conf.TLSConfig, serverAddresses ...string) (*BroadcastWrapper, error) {
+	requestClient, err := NewClient(tlsConfig)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
 	return &BroadcastWrapper{
 		serverAddresses: serverAddresses,
-		client:          &Client{},
-	}
+		client:          requestClient,
+	}, nil
 }
 
 func (b *BroadcastWrapper) Broadcast(request ClusterMessage) error {

--- a/remoting/client_test.go
+++ b/remoting/client_test.go
@@ -2,15 +2,17 @@ package remoting
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
+	"github.com/squareup/pranadb/conf"
 	"github.com/squareup/pranadb/errors"
 	"github.com/squareup/pranadb/protos/squareup/cash/pranadb/v1/clustermsgs"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 func TestRPC(t *testing.T) {
-	server := startServerWithListener(t, &echoListener{})
+	server := startServerWithListener(t, &echoListener{}, conf.TLSConfig{})
 	defer stopServers(t, server)
 
 	client := &Client{}
@@ -44,7 +46,7 @@ func TestRPCPranaError(t *testing.T) {
 
 func testRPCError(t *testing.T, respErr error, checkFunc func(*testing.T, errors.PranaError)) {
 	t.Helper()
-	server := startServerWithListener(t, &returnErrListener{err: respErr})
+	server := startServerWithListener(t, &returnErrListener{err: respErr}, conf.TLSConfig{})
 	defer stopServers(t, server)
 
 	client := &Client{}
@@ -62,7 +64,7 @@ func testRPCError(t *testing.T, respErr error, checkFunc func(*testing.T, errors
 }
 
 func TestRPCConnectionError(t *testing.T) {
-	server := startServerWithListener(t, &echoListener{})
+	server := startServerWithListener(t, &echoListener{}, conf.TLSConfig{})
 	defer stopServers(t, server)
 
 	client := &Client{}
@@ -92,7 +94,7 @@ func TestRPCConnectionError(t *testing.T) {
 }
 
 func TestRPCServerNotAvailable(t *testing.T) {
-	server := startServerWithListener(t, &echoListener{})
+	server := startServerWithListener(t, &echoListener{}, conf.TLSConfig{})
 
 	client := &Client{}
 
@@ -124,7 +126,7 @@ func TestBroadcast(t *testing.T) {
 		serverAddresses = append(serverAddresses, address)
 		listener := &echoListener{}
 		listeners = append(listeners, listener)
-		servers = append(servers, startServerWithListenerAndAddresss(t, listener, address))
+		servers = append(servers, startServerWithListenerAndAddresss(t, listener, address, conf.TLSConfig{}))
 	}
 	defer stopServers(t, servers...)
 
@@ -149,7 +151,7 @@ func TestBroadcastErrorAllServers(t *testing.T) {
 	for i := 0; i < numServers; i++ {
 		address := fmt.Sprintf("localhost:%d", 7888+i)
 		serverAddresses = append(serverAddresses, address)
-		servers = append(servers, startServerWithListenerAndAddresss(t, listener, address))
+		servers = append(servers, startServerWithListenerAndAddresss(t, listener, address, conf.TLSConfig{}))
 	}
 	defer stopServers(t, servers...)
 
@@ -218,7 +220,7 @@ func testBroadcastErrorOneServer(t *testing.T, respErr error, errDelay time.Dura
 		} else {
 			listener = &echoListener{delay: nonErrDelay}
 		}
-		servers = append(servers, startServerWithListenerAndAddresss(t, listener, address))
+		servers = append(servers, startServerWithListenerAndAddresss(t, listener, address, conf.TLSConfig{}))
 	}
 	defer stopServers(t, servers...)
 
@@ -262,7 +264,7 @@ func TestBroadcastNotEnoughServers(t *testing.T) {
 	}
 
 	// Just one server
-	server := startServerWithListenerAndAddresss(t, &echoListener{}, serverAddresses[0])
+	server := startServerWithListenerAndAddresss(t, &echoListener{}, serverAddresses[0], conf.TLSConfig{})
 	defer stopServers(t, server)
 
 	client := &Client{}
@@ -285,7 +287,7 @@ func TestBroadcastJustEnoughServers(t *testing.T) {
 
 	// Just one server
 	listener := &echoListener{}
-	server := startServerWithListenerAndAddresss(t, listener, serverAddresses[0])
+	server := startServerWithListenerAndAddresss(t, listener, serverAddresses[0], conf.TLSConfig{})
 	defer stopServers(t, server)
 
 	client := &Client{}
@@ -308,7 +310,7 @@ func TestBroadcastConnectionError(t *testing.T) {
 		serverAddresses = append(serverAddresses, address)
 		listener := &echoListener{}
 		listeners = append(listeners, listener)
-		servers = append(servers, startServerWithListenerAndAddresss(t, listener, address))
+		servers = append(servers, startServerWithListenerAndAddresss(t, listener, address, conf.TLSConfig{}))
 	}
 	defer stopServers(t, servers...)
 


### PR DESCRIPTION
We're enabling PranaDB to support encryption in transit. There's already a configuration for intra-cluster mTLS. The existing configuration sets up mTLS for the `raft` protocol.

This PR uses the intra-cluster mTLS configuration to configure the remoting service.

- [X] Tested `mtls_sql_test.go` which enables intra-cluster mTLS.

https://github.com/cashapp/pranadb/issues/535