### PR TITLE
Disallow zero-sized batches

### DIFF
--- a/api/grpc/server.go
+++ b/api/grpc/server.go
@@ -114,6 +114,9 @@ func (s *GRPCAPIServer) Stop() error {
 func (s *GRPCAPIServer) ExecuteStatement(in *service.ExecuteStatementRequest,
 	stream service.PranaDBService_ExecuteStatementServer) error {
 	defer common.PanicHandler()
+	if in.BatchSize <= 0 {
+		return errors.New("cannot use zero batch size")
+	}
 	var schema *common.Schema
 	if in.Schema != "" {
 		schema = s.metaController.GetOrCreateSchema(strings.ToLower(in.Schema))

--- a/api/grpc/server.go
+++ b/api/grpc/server.go
@@ -115,7 +115,7 @@ func (s *GRPCAPIServer) ExecuteStatement(in *service.ExecuteStatementRequest,
 	stream service.PranaDBService_ExecuteStatementServer) error {
 	defer common.PanicHandler()
 	if in.BatchSize <= 0 {
-		return errors.New("cannot use zero batch size")
+		return errors.New("cannot use non-positive batch sizes")
 	}
 	var schema *common.Schema
 	if in.Schema != "" {


### PR DESCRIPTION
Querying Prana with BatchSize==0 causes it to get stuck sending empty rows in a
loop because the breaking condition cannot be true:
```
if numRows < batchSize {
    break
}
```