### PR TITLE
Optimise away linearizable get

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -20,6 +20,8 @@ const (
 type Cluster interface {
 	ExecuteForwardBatch(shardID uint64, batch []byte) error
 
+	GetLastPersistedBatch(shardID uint64) ([]byte, error)
+
 	// WriteBatch writes a batch reliably to storage
 	WriteBatch(batch *WriteBatch, localOnly bool) error
 

--- a/cluster/fake/fake_cluster.go
+++ b/cluster/fake/fake_cluster.go
@@ -497,3 +497,7 @@ func (f *FakeCluster) RegisterEndFill() {
 
 func (f *FakeCluster) TableDropped(tableID uint64) {
 }
+
+func (f *FakeCluster) GetLastPersistedBatch(shardID uint64) ([]byte, error) {
+	return nil, nil
+}

--- a/cluster/write_batch.go
+++ b/cluster/write_batch.go
@@ -7,6 +7,7 @@ import (
 // WriteBatch represents some Puts and deletes that will be written atomically by the underlying storage implementation
 type WriteBatch struct {
 	ShardID    uint64
+	BatchID    []byte
 	Puts       []byte
 	Deletes    []byte
 	NumPuts    int
@@ -44,11 +45,24 @@ func (wb *WriteBatch) HasPuts() bool {
 	return len(wb.Puts) > 0
 }
 
+func (wb *WriteBatch) SetBatchID(id []byte) {
+	if len(id) != 16 {
+		panic("id wrong length")
+	}
+	wb.BatchID = id
+}
+
 func (wb *WriteBatch) Serialize(buff []byte) []byte {
 	buff = common.AppendUint32ToBufferLE(buff, uint32(wb.NumPuts))
 	buff = common.AppendUint32ToBufferLE(buff, uint32(wb.NumDeletes))
 	buff = append(buff, wb.Puts...)
 	buff = append(buff, wb.Deletes...)
+	if wb.BatchID == nil {
+		buff = append(buff, 0)
+	} else {
+		buff = append(buff, 1)
+		buff = append(buff, wb.BatchID...)
+	}
 	return buff
 }
 

--- a/pull/exec/remote_executor_test.go
+++ b/pull/exec/remote_executor_test.go
@@ -167,6 +167,10 @@ type testCluster struct {
 	rowsByShardOrig map[uint64]*common.Rows
 }
 
+func (t *testCluster) GetLastPersistedBatch(shardID uint64) ([]byte, error) {
+	panic("implement me")
+}
+
 func (t *testCluster) LocalIterator(startKeyPrefix []byte, endKeyPrefix []byte) cluster.KVIterator {
 	panic("implement me")
 }

--- a/push/engine.go
+++ b/push/engine.go
@@ -2,6 +2,7 @@ package push
 
 import (
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/squareup/pranadb/failinject"
 	"github.com/squareup/pranadb/interruptor"
 	"github.com/squareup/pranadb/parplan"
@@ -360,17 +361,19 @@ type RawRow struct {
 	Row              []byte
 }
 
-func (p *Engine) HandleBatch(shardID uint64, rowsBatch []cluster.ForwardRow, first bool) (int64, error) {
+func (p *Engine) HandleBatch(writeBatch *cluster.WriteBatch, rowGetter sched.RowGetter, rowsBatch []cluster.ForwardRow, first bool) (int64, error) {
 	rawRows := make(map[uint64][]RawRow)
+
+	ctx := exec.NewExecutionContext(writeBatch, rowGetter, -1)
 
 	if first {
 		// For the first batch we actually load it directly from the receiver table - there may be pending data there
 		// That was undelivered from the last time the server was started - we need to deliver everything in there first
-		return p.loadReceivedRows(shardID)
+		return p.loadReceivedRows(ctx)
 	}
 
 	receiveBatch := &receiveBatch{
-		writeBatch: cluster.NewWriteBatch(shardID),
+		ctx: ctx,
 	}
 
 	nr := len(rowsBatch)
@@ -385,7 +388,7 @@ func (p *Engine) HandleBatch(shardID uint64, rowsBatch []cluster.ForwardRow, fir
 		})
 		rawRows[row.RemoteConsumerID] = consumerRows
 		// TODO we can delete range instead of deleting one by one
-		receiveBatch.writeBatch.AddDelete(row.KeyBytes)
+		writeBatch.AddDelete(row.KeyBytes)
 	}
 
 	receiveBatch.rawRows = rawRows
@@ -408,11 +411,12 @@ func (p *Engine) removeScheduler(shardID uint64) {
 }
 
 type receiveBatch struct {
-	writeBatch *cluster.WriteBatch
-	rawRows    map[uint64][]RawRow
+	ctx     *exec.ExecutionContext
+	rawRows map[uint64][]RawRow
 }
 
-func (p *Engine) loadReceivedRows(receivingShardID uint64) (int64, error) {
+func (p *Engine) loadReceivedRows(ctx *exec.ExecutionContext) (int64, error) {
+	receivingShardID := ctx.WriteBatch.ShardID
 	keyStartPrefix := table.EncodeTableKeyPrefix(common.ReceiverTableID, receivingShardID, 16)
 	keyEndPrefix := table.EncodeTableKeyPrefix(common.ReceiverTableID+1, receivingShardID, 16)
 
@@ -427,8 +431,8 @@ func (p *Engine) loadReceivedRows(receivingShardID uint64) (int64, error) {
 	}
 
 	batch := &receiveBatch{
-		writeBatch: cluster.NewWriteBatch(receivingShardID),
-		rawRows:    make(map[uint64][]RawRow),
+		ctx:     ctx,
+		rawRows: make(map[uint64][]RawRow),
 	}
 
 	var receiverSequence uint64
@@ -441,7 +445,7 @@ func (p *Engine) loadReceivedRows(receivingShardID uint64) (int64, error) {
 			Row:              kvPair.Value,
 		})
 		batch.rawRows[remoteConsumerID] = rows
-		batch.writeBatch.AddDelete(kvPair.Key)
+		ctx.WriteBatch.AddDelete(kvPair.Key)
 	}
 
 	if err := p.processReceiveBatch(batch); err != nil {
@@ -452,7 +456,7 @@ func (p *Engine) loadReceivedRows(receivingShardID uint64) (int64, error) {
 }
 
 func (p *Engine) processReceiveBatch(batch *receiveBatch) error {
-	ctx := exec.NewExecutionContext(batch.writeBatch, -1)
+
 	for entityID, rawRows := range batch.rawRows {
 
 		rcVal, ok := p.remoteConsumers.Load(entityID)
@@ -492,10 +496,11 @@ func (p *Engine) processReceiveBatch(batch *receiveBatch) error {
 		}
 		rowsBatch := exec.NewRowsBatch(rows, entries)
 
-		if err := remoteConsumer.RowsHandler.HandleRemoteRows(rowsBatch, ctx); err != nil {
+		if err := remoteConsumer.RowsHandler.HandleRemoteRows(rowsBatch, batch.ctx); err != nil {
 			return errors.WithStack(err)
 		}
 	}
+	ctx := batch.ctx
 	if len(ctx.RemoteBatches) > 0 {
 		rb := make([]uint64, len(ctx.RemoteBatches))
 		i := 0
@@ -513,9 +518,18 @@ func (p *Engine) processReceiveBatch(batch *receiveBatch) error {
 	}
 
 	// If we get this far we can commit any local changes and deletes from the receiver table
-	if err := p.cluster.WriteBatch(batch.writeBatch, true); err != nil {
-		return errors.WithStack(err)
+	if ctx.WriteBatch.HasWrites() {
+		// Generate a batch id
+		uid, err := uuid.NewRandom()
+		if err != nil {
+			return err
+		}
+		ctx.WriteBatch.SetBatchID(uid[:])
+		if err := p.cluster.WriteBatch(ctx.WriteBatch, true); err != nil {
+			return errors.WithStack(err)
+		}
 	}
+
 	return nil
 }
 

--- a/push/exec/exec.go
+++ b/push/exec/exec.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"github.com/squareup/pranadb/cluster"
 	"github.com/squareup/pranadb/common"
+	"github.com/squareup/pranadb/push/sched"
 )
 
 type PushExecutor interface {
@@ -21,10 +22,11 @@ type PushExecutor interface {
 	ColsVisible() []bool
 }
 
-func NewExecutionContext(writeBatch *cluster.WriteBatch, fillTableID int64) *ExecutionContext {
+func NewExecutionContext(writeBatch *cluster.WriteBatch, rowGetter sched.RowGetter, fillTableID int64) *ExecutionContext {
 	return &ExecutionContext{
 		WriteBatch:  writeBatch,
 		FillTableID: fillTableID,
+		Getter:      rowGetter,
 	}
 }
 
@@ -32,6 +34,7 @@ type ExecutionContext struct {
 	WriteBatch    *cluster.WriteBatch
 	RemoteBatches map[uint64]*cluster.WriteBatch
 	FillTableID   int64
+	Getter        sched.RowGetter
 }
 
 func (e *ExecutionContext) AddToForwardBatch(shardID uint64, key []byte, value []byte) {

--- a/push/sched/scheduler.go
+++ b/push/sched/scheduler.go
@@ -1,6 +1,7 @@
 package sched
 
 import (
+	"bytes"
 	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -74,10 +75,12 @@ type ShardScheduler struct {
 	processLock                  sync.Mutex
 	processingPaused             bool
 	fillRun                      int
+	lastBatchID                  []byte
+	lastBatchProcessed           bool
 }
 
 type RowsBatchHandler interface {
-	HandleBatch(shardID uint64, rows []cluster.ForwardRow, first bool) (int64, error)
+	HandleBatch(writeBatch *cluster.WriteBatch, rowGetter RowGetter, rows []cluster.ForwardRow, first bool) (int64, error)
 }
 
 // ShardFailListener is called when a shard fails - this is only caused for unretryable errors where we need to stop
@@ -100,6 +103,32 @@ type actionEntry struct {
 	action            func() error
 	weight            int
 	completionChannel chan error
+}
+
+type RowGetter interface {
+	Get(key []byte) ([]byte, error)
+}
+
+func (s *ShardScheduler) Get(key []byte) ([]byte, error) {
+	localGet := false
+	if s.lastBatchID != nil {
+		if s.lastBatchProcessed {
+			localGet = true
+		} else {
+			lastBatch, err := s.clust.GetLastPersistedBatch(s.shardID)
+			if err != nil {
+				return nil, err
+			}
+			if bytes.Compare(lastBatch, s.lastBatchID) == 0 {
+				s.lastBatchProcessed = true
+				localGet = true
+			}
+		}
+	}
+	if localGet {
+		return s.clust.LocalGet(key)
+	}
+	return s.clust.LinearizableGet(s.shardID, key)
 }
 
 func NewShardScheduler(shardID uint64, batchHandler RowsBatchHandler, shardFailListener ShardFailListener,
@@ -336,18 +365,17 @@ func (s *ShardScheduler) getForwardWriteBatch() *WriteBatchEntry {
 		for _, batch := range s.forwardWrites {
 			nextBatchIndex++
 			numPuts := getNumPuts(batch.writeBatch)
-			combinedEntries = append(combinedEntries, batch.writeBatch[10:]...)
+			combinedEntries = append(combinedEntries, batch.writeBatch[3:]...)
 			entries += int(numPuts)
 			completionChannels = append(completionChannels, batch.completionChannels[0])
-			if entries >= s.maxForwardWriteBatchSize {
+			if entries >= s.maxForwardWriteBatchSize || nextBatchIndex == 255 {
 				break
 			}
 		}
-		bigBatch := make([]byte, 0, len(combinedEntries)+10)
+		bigBatch := make([]byte, 0, len(combinedEntries)+3)
 		bigBatch = append(bigBatch, s.forwardWrites[0].writeBatch[0]) // shardStateMachineCommandForwardWrite
 		bigBatch = append(bigBatch, s.forwardWrites[0].writeBatch[1]) // 0 - not a fill
-		bigBatch = common.AppendUint32ToBufferLE(bigBatch, uint32(entries))
-		bigBatch = common.AppendUint32ToBufferLE(bigBatch, 0)
+		bigBatch = append(bigBatch, byte(nextBatchIndex))             // number of batches in the write
 		bigBatch = append(bigBatch, combinedEntries...)
 		s.forwardWrites = s.forwardWrites[nextBatchIndex:]
 		s.queuedWriteRows -= entries
@@ -363,7 +391,7 @@ func (s *ShardScheduler) getForwardWriteBatch() *WriteBatchEntry {
 }
 
 func getNumPuts(batch []byte) uint32 {
-	numPuts, _ := common.ReadUint32FromBufferLE(batch, 2)
+	numPuts, _ := common.ReadUint32FromBufferLE(batch, 3)
 	return numPuts
 }
 
@@ -479,13 +507,18 @@ func (s *ShardScheduler) runLoop() {
 }
 
 func (s *ShardScheduler) processBatch(rowsToProcess []cluster.ForwardRow, first bool, fill bool) bool {
-	lastSequence, err := s.batchHandler.HandleBatch(s.shardID, rowsToProcess, first)
+	writeBatch := cluster.NewWriteBatch(s.shardID)
+	lastSequence, err := s.batchHandler.HandleBatch(writeBatch, s, rowsToProcess, first)
 	if err != nil {
 		s.setFailed(err)
 		return false
 	}
 	if !fill && lastSequence != -1 { // -1 represents no rows returned
 		atomic.StoreUint64(&s.lastProcessedReceiverSeq, uint64(lastSequence))
+	}
+	if writeBatch.BatchID != nil {
+		s.lastBatchID = writeBatch.BatchID
+		s.lastBatchProcessed = false
 	}
 	return true
 }


### PR DESCRIPTION
Source and MVs need to perform gets against their state to fetch previous state. Previously we were using a linearizable get for this, to ensure the state being read reflects the last batch written. However a LG is slow and seriously affects performance.
This PR introduces an optimisation that allows us to avoid the LG in the vast majority of cases.
Now, when we write a batch from processing we include a batch id, which is a random UUID. When the batch is written into the state machine, the sm records the id of the last batch written.
Before performing the get, we first ask the the local replica sm if it has seen the last batch written from that processor, if it has, then a local get can be performed, if not an lg must be performed.