### PR TITLE
Ignore proposal queue pause and improve config for pebble

### DIFF
--- a/cmd/pranadb/runner_test.go
+++ b/cmd/pranadb/runner_test.go
@@ -121,5 +121,7 @@ func createConfigWithAllFields() conf.Config {
 			ClientCertsPath: "intra-cluster-client-certs-path",
 			ClientAuth:      "require-and-verify-client-cert",
 		},
+
+		DataCacheSize: 12345,
 	}
 }

--- a/cmd/pranadb/testdata/config.hcl
+++ b/cmd/pranadb/testdata/config.hcl
@@ -90,3 +90,5 @@ intra-cluster-tls-key-path      = "intra-cluster-key-path"
 intra-cluster-tls-cert-path     = "intra-cluster-cert-path"
 intra-cluster-tls-client-certs-path = "intra-cluster-client-certs-path"
 intra-cluster-tls-client-auth = "require-and-verify-client-cert"
+
+data-cache-size                   = 12345

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -22,6 +22,7 @@ const (
 	DefaultMaxProcessBatchSize        = 2000
 	DefaultMaxForwardWriteBatchSize   = 500
 	DefaultMaxTableReaperBatchSize    = 1000
+	DefaultDataCacheSize              = 1024 * 1024 * 1024
 )
 
 type Config struct {
@@ -73,6 +74,7 @@ type Config struct {
 	MaxProcessBatchSize          int
 	MaxForwardWriteBatchSize     int
 	MaxTableReaperBatchSize      int
+	DataCacheSize                int64
 }
 
 type TLSConfig struct {
@@ -139,6 +141,9 @@ func (c *Config) ApplyDefaults() {
 	}
 	if c.MaxTableReaperBatchSize == 0 {
 		c.MaxTableReaperBatchSize = DefaultMaxTableReaperBatchSize
+	}
+	if c.DataCacheSize == 0 {
+		c.DataCacheSize = DefaultDataCacheSize
 	}
 }
 
@@ -290,6 +295,9 @@ func (c *Config) Validate() error { //nolint:gocyclo
 			return errors.NewInvalidConfigurationError("IntraClusterTLSConfig.ClientCertsPath must be provided if intra cluster TLS is enabled")
 		}
 	}
+	if c.DataCacheSize < 1 {
+		return errors.NewInvalidConfigurationError("DataCacheSize must be > 0")
+	}
 	return nil
 }
 
@@ -325,6 +333,7 @@ func NewDefaultConfig() *Config {
 		MaxProcessBatchSize:        DefaultMaxProcessBatchSize,
 		MaxForwardWriteBatchSize:   DefaultMaxForwardWriteBatchSize,
 		MaxTableReaperBatchSize:    DefaultMaxTableReaperBatchSize,
+		DataCacheSize:              DefaultDataCacheSize,
 	}
 }
 
@@ -338,6 +347,7 @@ func NewTestConfig(fakeKafkaID int64) *Config {
 		MaxProcessBatchSize:      DefaultMaxProcessBatchSize,
 		MaxForwardWriteBatchSize: DefaultMaxForwardWriteBatchSize,
 		MaxTableReaperBatchSize:  DefaultMaxTableReaperBatchSize,
+		DataCacheSize:            DefaultDataCacheSize,
 		NodeID:                   0,
 		NumShards:                10,
 		TestServer:               true,

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -213,9 +213,15 @@ func locksCompactionGreaterThanDataSnapshotEntries() Config {
 	return cnf
 }
 
-func NodeIDOutOfRangeConf() Config {
+func nodeIDOutOfRangeConf() Config {
 	cnf := confAllFields
 	cnf.NodeID = len(cnf.RaftListenAddresses)
+	return cnf
+}
+
+func invalidDataCacheSize() Config {
+	cnf := confAllFields
+	cnf.DataCacheSize = -1
 	return cnf
 }
 
@@ -346,7 +352,7 @@ var invalidConfigs = []configPair{
 	{"PDB3000 - Invalid configuration: KafkaBroker testbroker, invalid ClientType, must be 1 or 2", invalidBrokerClientTypeConf()},
 	{"PDB3000 - Invalid configuration: GRPCAPIServerListenAddresses must be specified", invalidGRPCAPIServerListenAddress()},
 	{"PDB3000 - Invalid configuration: HTTPAPIServerListenAddresses must be specified", invalidHTTPAPIServerListenAddress()},
-	{"PDB3000 - Invalid configuration: NodeID must be in the range 0 (inclusive) to len(RaftListenAddresses) (exclusive)", NodeIDOutOfRangeConf()},
+	{"PDB3000 - Invalid configuration: NodeID must be in the range 0 (inclusive) to len(RaftListenAddresses) (exclusive)", nodeIDOutOfRangeConf()},
 	{"PDB3000 - Invalid configuration: ReplicationFactor must be >= 3", invalidReplicationFactorConfig()},
 	{"PDB3000 - Invalid configuration: Number of RaftListenAddresses must be >= ReplicationFactor", invalidRaftListenAddressesConfig()},
 	{"PDB3000 - Invalid configuration: Number of RaftListenAddresses must be same as number of RemotingListenAddresses", raftAndRemotingListenAddressedDifferentLengthConfig()},
@@ -392,6 +398,8 @@ var invalidConfigs = []configPair{
 	{"PDB3000 - Invalid configuration: IntraClusterTLSConfig.KeyPath must be specified if intra cluster TLS is enabled", intraClusterTLSKeyPathNotSpecifiedConfig()},
 	{"PDB3000 - Invalid configuration: IntraClusterTLSConfig.CertPath must be specified if intra cluster TLS is enabled", intraClusterTLSCertPathNotSpecifiedConfig()},
 	{"PDB3000 - Invalid configuration: IntraClusterTLSConfig.ClientCertsPath must be provided if intra cluster TLS is enabled", intraClusterTLSCAPathNotSpecifiedConfig()},
+
+	{"PDB3000 - Invalid configuration: DataCacheSize must be > 0", invalidDataCacheSize()},
 }
 
 func TestValidate(t *testing.T) {

--- a/dragonboat/config/config.go
+++ b/dragonboat/config/config.go
@@ -914,6 +914,10 @@ type ExpertConfig struct {
 	// TestGossipProbeInterval define the probe interval used by the gossip
 	// service in tests.
 	TestGossipProbeInterval time.Duration
+
+	// Added by Prana
+	// If true then continue to allow proposals when the logdb is busy
+	IgnorePauseOnProposals bool
 }
 
 // GossipConfig contains configurations for the gossip service. Gossip service

--- a/dragonboat/node.go
+++ b/dragonboat/node.go
@@ -145,7 +145,12 @@ func newNode(peers map[uint64]string,
 	metrics *logDBMetrics,
 	sysEvents *sysEventListener) (*node, error) {
 	notifyCommit := nhConfig.NotifyCommit
-	proposals := newEntryQueue(incomingProposalsMaxLen, lazyFreeCycle)
+	var proposals *entryQueue
+	if nhConfig.Expert.IgnorePauseOnProposals {
+		proposals = newEntryQueueIgnoringPause(incomingProposalsMaxLen, lazyFreeCycle)
+	} else {
+		proposals = newEntryQueue(incomingProposalsMaxLen, lazyFreeCycle)
+	}
 	readIndexes := newReadIndexQueue(incomingReadIndexMaxLen)
 	configChangeC := make(chan configChangeRequest, 1)
 	snapshotC := make(chan rsm.SSRequest, 1)

--- a/remoting/server.go
+++ b/remoting/server.go
@@ -220,7 +220,7 @@ func (c *connection) handleMessageAsync0(msg []byte) {
 	handler := c.s.lookupMessageHandler(request.requestMessage)
 	respMsg, respErr := handler.HandleMessage(request.requestMessage)
 	if respErr != nil {
-		log.Errorf("failed to handle cluster message %+v", respErr)
+		log.Debugf("failed to handle cluster message %+v", respErr)
 	}
 	if request.requiresResponse && !c.s.responsesDisabled.Get() {
 		if err := c.sendResponse(request, respMsg, respErr); err != nil {


### PR DESCRIPTION
There appears to be a bug in Dragonboat where we receive ErrSystemBusy when ingesting under heavy load. This is because Dragonboat has a back pressure mechanism where it listens to see whether the DB is busy and then pauses the propose queue. When the propose queue is paused any attempt to add to it returns ErrSystemBusy. However when the DB is not busy again the queue does not seem to get unpaused, and the system grinds to a halt.
We do not need this backpressure mechanism in Prana as we effectively throttle our writes anyway as they all are written via processors and there can only be one oustanding propose per processor at any one time. 
This PR disables the pause on the propose queue.
It also includes the beginning of a more tuned Pebble config, in particular a global Pebble cache is introduced with a large default size (1GB) this greatly improves performance of sources and MVs as gets are our biggest performance bottleneck.
We should also consider providing per table level in memory caching too, as with a global cache a large source can end up evicting entries for other smaller tables, e.g. MVs.