### PR TITLE
Run integration tests every 2 hours

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,7 +1,7 @@
 name: "Continuous Integration Tests"
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 */2 * * *'
   push:
     branches:
       - force-integration-tests # Push this branch to force this job to run


### PR DESCRIPTION
As they're backing up on a 1 hour schedule